### PR TITLE
Phase 14b-3: ImageUrlBuilder — on-demand thumbnails on iManager 2.0

### DIFF
--- a/boot/Frontend/ImageUrlBuilder.php
+++ b/boot/Frontend/ImageUrlBuilder.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Frontend;
+
+use Imanager\Files\ImageProcessingException;
+use Imanager\Files\ImageProcessor;
+
+/**
+ * Builds public URLs for image-field values stored on items, generating
+ * resized thumbnails on demand and caching them next to the original.
+ *
+ * The migration writes image entries with the 1.x-shaped path
+ * `data/uploads/<itemDir>/` (the legacy upload prefix). This builder
+ * transparently rewrites that to the 2.0 upload root configured at
+ * construction time and produces a thumbnail filename of
+ * `<W>x<H>_<file>` inside a sibling `thumbnail/` directory — same
+ * convention 1.x used so the existing on-disk thumbnails stay reachable
+ * without re-encoding.
+ *
+ * Pass `width = 0` (or `height = 0`) to keep the source aspect ratio
+ * along that axis. Both 0 → return the original image URL, no resize.
+ */
+final readonly class ImageUrlBuilder
+{
+    public function __construct(
+        private ImageProcessor $processor,
+        private string $scriptorRoot,
+        private string $legacyPathPrefix = 'data/uploads/',
+        private string $modernPathPrefix = 'data/uploads-2.0/',
+    ) {}
+
+    /**
+     * @param array<string, mixed> $image  field-value entry (`path`, `name`, …)
+     */
+    public function url(array $image, int $width = 0, int $height = 0): string
+    {
+        $name = (string) ($image['name'] ?? '');
+        $path = (string) ($image['path'] ?? '');
+        if ($name === '' || $path === '') {
+            return '';
+        }
+
+        $publicDir = $this->rewritePath($path);
+        if ($width <= 0 && $height <= 0) {
+            return $this->joinUrl($publicDir, $name);
+        }
+
+        $thumbName = self::thumbnailFilename($name, $width, $height);
+        $absDir    = $this->scriptorRoot . '/' . trim($publicDir, '/');
+        $absThumb  = $absDir . '/thumbnail/' . $thumbName;
+        $absSource = $absDir . '/' . $name;
+
+        if (! is_file($absThumb) && is_file($absSource)) {
+            $this->generateThumbnail($absSource, $absThumb, $width, $height);
+        }
+
+        return $this->joinUrl($publicDir . 'thumbnail/', $thumbName);
+    }
+
+    /**
+     * Rewrites a legacy 1.x `data/uploads/...` path to the configured 2.0
+     * upload root, leaving foreign or already-modern paths untouched.
+     */
+    private function rewritePath(string $path): string
+    {
+        $clean = trim($path, '/');
+        if ($clean === '') {
+            return $this->modernPathPrefix;
+        }
+        $legacy = trim($this->legacyPathPrefix, '/');
+        if ($legacy !== '' && str_starts_with($clean, $legacy . '/')) {
+            $clean = trim($this->modernPathPrefix, '/') . '/' . substr($clean, \strlen($legacy) + 1);
+        }
+        return $clean . '/';
+    }
+
+    private function joinUrl(string $dir, string $file): string
+    {
+        return '/' . trim($dir, '/') . '/' . ltrim($file, '/');
+    }
+
+    private function generateThumbnail(string $source, string $target, int $width, int $height): void
+    {
+        $dir = \dirname($target);
+        if (! is_dir($dir) && ! @mkdir($dir, 0o755, true) && ! is_dir($dir)) {
+            return;
+        }
+        try {
+            $bytes = $this->processor->thumbnail($source, $width, $height);
+        } catch (ImageProcessingException) {
+            return;
+        }
+        @file_put_contents($target, $bytes);
+    }
+
+    private static function thumbnailFilename(string $name, int $width, int $height): string
+    {
+        return \sprintf('%dx%d_%s', max(0, $width), max(0, $height), $name);
+    }
+}

--- a/boot/Frontend/Site.php
+++ b/boot/Frontend/Site.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Scriptor\Boot\Frontend;
 
 use Imanager\Cache\FilesystemCache;
+use Imanager\Files\ImageProcessor;
 use Imanager\Http\Request;
 use Imanager\Http\UrlSegments;
 use Imanager\Templating\TemplateRenderer;
@@ -40,6 +41,7 @@ class Site
     public PageRepository $pages;
     public TemplateRenderer $templateParser;
     public FilesystemCache $cache;
+    public ImageUrlBuilder $images;
 
     /** @var array<string, mixed> */
     public array $config;
@@ -87,6 +89,10 @@ class Site
             $container->get(\Imanager\Storage\ItemRepository::class),
         );
         $this->cache = $container->get(FilesystemCache::class);
+        $this->images = new ImageUrlBuilder(
+            $container->get(ImageProcessor::class),
+            $scriptorRoot,
+        );
         $this->templateParser = new TemplateRenderer();
         $this->input = Request::fromGlobals();
         $this->siteUrl  = self::detectSiteUrl();
@@ -229,9 +235,20 @@ class Site
     {
         $uri = $_SERVER['REQUEST_URI'] ?? '/';
         $path = explode('?', $uri, 2)[0];
-        $segmentsPath = $this->urlSegments->path(trailingSlash: true);
-        if ($segmentsPath !== '' && str_ends_with($path, $segmentsPath)) {
-            $path = substr($path, 0, -\strlen($segmentsPath));
+        // Strip the segments path off the request URI in either form
+        // (with or without trailing slash) so the base path always ends
+        // with a single `/`.
+        foreach ([
+            $this->urlSegments->path(trailingSlash: true),
+            $this->urlSegments->path(trailingSlash: false),
+        ] as $segmentsPath) {
+            if ($segmentsPath !== '' && str_ends_with($path, $segmentsPath)) {
+                $path = substr($path, 0, -\strlen($segmentsPath));
+                break;
+            }
+        }
+        if ($path === '' || ! str_ends_with($path, '/')) {
+            $path .= '/';
         }
         return $path === '' ? '/' : $path;
     }

--- a/site/themes/basic/lib/Basic.php
+++ b/site/themes/basic/lib/Basic.php
@@ -277,7 +277,7 @@ class BasicTheme extends Site
         if (! \is_array($first) || ! isset($first['name'], $first['path'])) {
             return '';
         }
-        $imageUrl = $this->getBasePath() . self::imagePath($first);
+        $imageUrl = $this->getBasePath() . ltrim($this->images->url($first, width: 800, height: 350), '/');
         $info = '';
         if (! empty($first['title'])) {
             $info = $this->templateParser->render($this->tpls['art_list_image_caption'], [
@@ -379,7 +379,7 @@ class BasicTheme extends Site
         if (! \is_array($first) || ! isset($first['name'], $first['path'])) {
             return '';
         }
-        $imageUrl = $this->getBasePath() . self::imagePath($first);
+        $imageUrl = $this->getBasePath() . ltrim($this->images->url($first, width: 1200), '/');
         return $this->templateParser->render($this->tpls['hero'], [
             'SRC'  => $imageUrl,
             'INFO' => $this->sanitizer->markdown((string) ($first['title'] ?? '')),
@@ -582,23 +582,6 @@ class BasicTheme extends Site
     {
         $format = (string) ($this->themeConfig['datetime_format'] ?? 'd F Y');
         return $this->dateTime($timestamp)->format($format);
-    }
-
-    /**
-     * @param array<string, mixed> $image
-     */
-    private static function imagePath(array $image): string
-    {
-        $path = (string) ($image['path'] ?? '');
-        $name = (string) ($image['name'] ?? '');
-        if ($path === '' || $name === '') {
-            return '';
-        }
-        $clean = '/' . ltrim($path, '/');
-        if (! str_ends_with($clean, '/')) {
-            $clean .= '/';
-        }
-        return $clean . $name;
     }
 
     /**


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                             
  Image rendering goes through a new `Frontend\ImageUrlBuilder` that wraps the                                                                                                                                                                                                                                                                                                             
  iManager 2.0 `ImageProcessor`. The builder rewrites legacy 1.x upload paths                                                                                                                                                                                                                                                                                                              
  (`data/uploads/<itemDir>/`) to the post-migration root (`data/uploads-2.0/`),                                                                                                                                                                                                                                                                                                            
  generates W×H thumbnails on first request, and caches them next to the                                                                                                                                                                                                                                                                                                                   
  original under `thumbnail/<W>x<H>_<file>` — keeping the 1.x naming convention                                                                                                                                                                                                                                                                                                            
  so existing thumbnails stay reachable without re-encoding.                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                           
  `Frontend\Site` exposes the builder as `$site->images`. BasicTheme's                                                                                                                                                                                                                                                                                                                     
  `renderHero()` and `renderArticleFigure()` call `$site->images->url(...)` with                                                                                                                                                                                                                                                                                                           
  size hints (1200×0 for hero, 800×350 for article-list figure) — the static                                                                                                                                                                                                                                                                                                               
  `imagePath()` bridge from 14b-2 is deleted.                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                           
  `Frontend\Site::getBasePath()` also gained a small fix: it now strips the                                                                                                                                                                                                                                                                                                                
  segments path off the request URI in either form (with or without trailing                                                                                                                                                                                                                                                                                                               
  slash) and always returns a path ending in `/`, so URLs built by                                                                                                                                                                                                                                                                                                                         
  concatenation against `$this->images->url(...)` don't collide with the                                                                                                                                                                                                                                                                                                                   
  leading slash of the asset path.                                                                                                                                                                                                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                           
  ## Test plan                                                                                                                                                                                                                                                                                                                                                                             
  - [x] `GET /` 200, 7.3 KB (hero rendered with 1200×0 thumb)                                                                                                                                                                                                                                                                                                                              
  - [x] `GET /scriptors-demo-page` 200, 7.3 KB                                                                                                                                                                                                                                                                                                                                             
  - [x] `GET /articles/` 200, 7.1 KB (article list with 800×350 figure)                                                                                                                                                                                                                                                                                                                    
  - [x] `GET /articles/page2/` 200, 5.8 KB                                                                                                                                                                                                                                                                                                                                                 
  - [x] `GET /articles/get-started-with-scriptor` 200, 7.4 KB (single article)                                                                                                                                                                                                                                                                                                             
  - [x] `GET /contact` 200, 7.1 KB                                                                                                                                                                                                                                                                                                                                                         
  - [x] `GET /this-does-not-exist` 404                                                                                                                                                                                                                                                                                                                                                     
  - [x] Thumbnails verified on disk + 200 image/jpeg over HTTP:                                                                                                                                                                                                                                                                                                                            
    `data/uploads-2.0/1.1.6/thumbnail/1200x0_*.jpeg` (1200×463)                                                                                                                                                                                                                                                                                                                            
    `data/uploads-2.0/1.3.6/thumbnail/1200x0_*.jpeg`                                                                                                                                                                                                                                                                                                                                       
    `data/uploads-2.0/1.3.6/thumbnail/800x350_*.jpeg` (782×350, aspect-preserved)                                                                                                                                                                                                                                                                                                          
  - [ ] Browser smoke against ServBay