### PR TITLE
Phase 14c-1: editor auth on iManager 2.0 (login/logout, CSRF)

### DIFF
--- a/boot/Editor/Auth/AuthModule.php
+++ b/boot/Editor/Auth/AuthModule.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Editor\Auth;
+
+use Scriptor\Boot\Editor\Editor;
+use Scriptor\Boot\Editor\UserRepository;
+
+/**
+ * Auth module — login form + login/logout handlers on the iManager 2.0
+ * Csrf + Request + SessionStore stack.
+ *
+ * Module contract for 14c-1: invoked by EditorRouter when the URL
+ * resolves to `/editor/auth*`. Side effects (session writes, redirects)
+ * happen inside `execute()`; render output lands on `$editor->pageContent`.
+ *
+ * Password verification goes through `password_verify()` against the
+ * bcrypt hash that the migrator preserved in the user item's `password`
+ * field (Phase 9 + iManager `PasswordFieldType`).
+ */
+final class AuthModule
+{
+    public function __construct(
+        private readonly Editor $editor,
+        private readonly UserRepository $users,
+        private readonly LoginAttempts $attempts,
+    ) {}
+
+    public function execute(): void
+    {
+        $this->checkAction();
+
+        if ($this->editor->isLoggedIn()) {
+            $this->redirect($this->editor->siteUrl . '/');
+        }
+        $this->editor->pageTitle = 'Login - Scriptor';
+        $this->editor->pageContent = $this->renderLoginForm();
+    }
+
+    private function checkAction(): void
+    {
+        if (! $this->editor->isLoggedIn()) {
+            $this->loginAction();
+            return;
+        }
+        if ($this->editor->urlSegments->get(1) === 'logout') {
+            $this->logoutAction();
+        }
+    }
+
+    private function loginAction(): void
+    {
+        if ($this->editor->input->postString('action') !== 'login') {
+            return;
+        }
+        if ($this->editor->input->isMethod('POST') === false) {
+            return;
+        }
+
+        $ip = self::clientIp();
+        if (! $this->attempts->isAllowed($ip)) {
+            $this->editor->addMsg('error', $this->t('error_max_login_attempts', [
+                'count' => (string) $this->attempts->lockoutMinutes(),
+            ]));
+            return;
+        }
+
+        if ($this->csrfRequired() && ! $this->editor->csrf->validate(
+            $this->editor->input->postString('tokenName'),
+            $this->editor->input->postString('tokenValue'),
+        )) {
+            $this->editor->addMsg('error', $this->t('error_csrf_token_mismatch') ?: 'CSRF token invalid.');
+            return;
+        }
+
+        $username = $this->editor->sanitizer->text($this->editor->input->postString('username'));
+        $password = $this->editor->input->postString('password');
+        if ($username === '' || $password === '') {
+            $this->attempts->recordFailure($ip);
+            $this->editor->addMsg('error', $this->t('error_login', [
+                'count' => (string) $this->attempts->remainingAttempts($ip),
+            ]));
+            return;
+        }
+
+        $user = $this->users->findByName($username);
+        $hash = self::extractHash($user?->data->get('password'));
+        if ($user === null || $hash === null || ! password_verify($password, $hash)) {
+            $this->attempts->recordFailure($ip);
+            $remaining = $this->attempts->remainingAttempts($ip);
+            $key = $remaining > 0 ? 'error_login' : 'error_max_login_attempts';
+            $this->editor->addMsg('error', $this->t($key, [
+                'count' => $remaining > 0
+                    ? (string) $remaining
+                    : (string) $this->attempts->lockoutMinutes(),
+            ]));
+            return;
+        }
+
+        $this->editor->session->set('loggedin', true);
+        $this->editor->session->set('userid', $user->id);
+        $this->editor->csrf->clear();
+        $this->attempts->reset();
+        $this->editor->flashMsg('success', $this->t('successful_login'));
+        $this->redirect($this->editor->siteUrl . '/');
+    }
+
+    private function logoutAction(): void
+    {
+        if ($this->csrfRequired() && ! $this->editor->csrf->validate(
+            $this->editor->input->getString('tokenName'),
+            $this->editor->input->getString('tokenValue'),
+        )) {
+            $this->editor->addMsg('error', $this->t('error_csrf_token_mismatch') ?: 'CSRF token invalid.');
+            return;
+        }
+        $this->editor->session->remove('loggedin');
+        $this->editor->session->remove('userid');
+        $this->editor->csrf->clear();
+        $this->editor->flashMsg('success', $this->t('successful_logout'));
+        $this->redirect($this->editor->siteUrl . '/auth/');
+    }
+
+    private function renderLoginForm(): string
+    {
+        $tokenName  = 'login_token';
+        $tokenValue = $this->editor->csrf->token($tokenName);
+
+        $html  = '<h1>' . htmlspecialchars($this->t('login_header'), \ENT_QUOTES) . '</h1>';
+        $html .= '<form id="login-form" action="" method="post">';
+        $html .= '<div class="form-control">';
+        $html .= '<label for="username">' . htmlspecialchars($this->t('username_label'), \ENT_QUOTES) . '</label>';
+        $html .= '<input type="text" id="username" name="username" autocomplete="username">';
+        $html .= '</div>';
+        $html .= '<div class="form-control">';
+        $html .= '<label for="pass">' . htmlspecialchars($this->t('password_label'), \ENT_QUOTES) . '</label>';
+        $html .= '<input type="password" id="pass" name="password" autocomplete="current-password">';
+        $html .= '</div>';
+        $html .= '<input type="hidden" name="action" value="login">';
+        $html .= '<input type="hidden" name="tokenName" value="' . htmlspecialchars($tokenName, \ENT_QUOTES) . '">';
+        $html .= '<input type="hidden" name="tokenValue" value="' . htmlspecialchars($tokenValue, \ENT_QUOTES) . '">';
+        $html .= '<button class="icons button" type="submit" name="submit">';
+        $html .= '<i class="gg-log-in"></i><span>' . htmlspecialchars($this->t('login_button'), \ENT_QUOTES) . '</span>';
+        $html .= '</button>';
+        $html .= '</form>';
+        return $html;
+    }
+
+    private function csrfRequired(): bool
+    {
+        return (bool) ($this->editor->config['protectCSRF'] ?? true);
+    }
+
+    /**
+     * @param array<string, string> $vars
+     */
+    private function t(string $key, array $vars = []): string
+    {
+        $template = $this->editor->i18n[$key] ?? $key;
+        if ($vars === []) {
+            return $template;
+        }
+        // Legacy templates use [[var]] placeholders.
+        foreach ($vars as $name => $value) {
+            $template = str_replace('[[' . $name . ']]', $value, $template);
+        }
+        return $template;
+    }
+
+    private function redirect(string $url): never
+    {
+        header('Location: ' . $url, true, 302);
+        exit;
+    }
+
+    /**
+     * The 2.0 PasswordFieldType writes the bcrypt hash as a plain string,
+     * but items migrated from 1.x still carry the legacy
+     * `PasswordFieldValue` wrapper `{__class, password, salt}`. Accept both.
+     */
+    private static function extractHash(mixed $value): ?string
+    {
+        if (\is_string($value) && $value !== '') {
+            return $value;
+        }
+        if (\is_array($value) && \is_string($value['password'] ?? null) && $value['password'] !== '') {
+            return $value['password'];
+        }
+        return null;
+    }
+
+    private static function clientIp(): string
+    {
+        $candidates = [
+            $_SERVER['HTTP_CLIENT_IP']        ?? null,
+            $_SERVER['HTTP_X_FORWARDED_FOR']  ?? null,
+            $_SERVER['REMOTE_ADDR']           ?? null,
+        ];
+        foreach ($candidates as $candidate) {
+            if (! \is_string($candidate) || $candidate === '') {
+                continue;
+            }
+            $candidate = trim(explode(',', $candidate)[0]);
+            if (filter_var($candidate, \FILTER_VALIDATE_IP) !== false) {
+                return $candidate;
+            }
+        }
+        return '0.0.0.0';
+    }
+}

--- a/boot/Editor/Auth/LoginAttempts.php
+++ b/boot/Editor/Auth/LoginAttempts.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Editor\Auth;
+
+use Imanager\Http\SessionStore;
+
+/**
+ * IP-scoped failed-login counter persisted in the editor session.
+ * Locks the IP out for `lockoutMinutes` once `maxAttempts` failures
+ * are recorded; a successful login or a passing `tick()` after the
+ * lockout window resets the counter.
+ */
+final readonly class LoginAttempts
+{
+    private const SESSION_KEY = 'login_attempts';
+
+    public function __construct(
+        private SessionStore $session,
+        private int $maxAttempts = 5,
+        private int $lockoutMinutes = 5,
+    ) {}
+
+    public function isAllowed(string $ip): bool
+    {
+        $state = $this->state($ip);
+        if ($state['attempts'] < $this->maxAttempts) {
+            return true;
+        }
+        if ($state['locked_until'] > 0 && time() >= $state['locked_until']) {
+            $this->reset();
+            return true;
+        }
+        return false;
+    }
+
+    public function recordFailure(string $ip): void
+    {
+        $state = $this->state($ip);
+        $state['attempts']++;
+        if ($state['attempts'] >= $this->maxAttempts) {
+            $state['locked_until'] = time() + ($this->lockoutMinutes * 60);
+        }
+        $this->session->set(self::SESSION_KEY, $state);
+    }
+
+    public function remainingAttempts(string $ip): int
+    {
+        $state = $this->state($ip);
+        return max(0, $this->maxAttempts - $state['attempts']);
+    }
+
+    public function lockoutMinutes(): int
+    {
+        return $this->lockoutMinutes;
+    }
+
+    public function reset(): void
+    {
+        $this->session->remove(self::SESSION_KEY);
+    }
+
+    /**
+     * @return array{ip: string, attempts: int, locked_until: int}
+     */
+    private function state(string $ip): array
+    {
+        $stored = $this->session->get(self::SESSION_KEY);
+        if (
+            \is_array($stored)
+            && ($stored['ip'] ?? null) === $ip
+            && \is_int($stored['attempts'] ?? null)
+        ) {
+            return [
+                'ip'           => $ip,
+                'attempts'     => $stored['attempts'],
+                'locked_until' => (int) ($stored['locked_until'] ?? 0),
+            ];
+        }
+        $fresh = ['ip' => $ip, 'attempts' => 0, 'locked_until' => 0];
+        $this->session->set(self::SESSION_KEY, $fresh);
+        return $fresh;
+    }
+}

--- a/boot/Editor/Editor.php
+++ b/boot/Editor/Editor.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Editor;
+
+use Imanager\Http\Csrf;
+use Imanager\Http\Request;
+use Imanager\Http\SessionStore;
+use Imanager\Http\UrlSegments;
+use Imanager\Templating\TemplateRenderer;
+use Imanager\Validation\Sanitizer as ImanagerSanitizer;
+use League\Container\Container;
+use Scriptor\Boot\Frontend\Sanitizer;
+
+/**
+ * Phase 14c-1 Editor surface — what the legacy editor theme files
+ * (theme/template.php, theme/header.php, theme/summary.php, plus the
+ * module render output) need from `$editor`:
+ *
+ *   - Properties:  config, siteUrl, themeUrl, version, csrf, msgs[],
+ *                  pageTitle, pageContent, breadcrumbs, jsConfig,
+ *                  i18n, input, sanitizer, urlSegments, session
+ *   - Helpers:     getProperty(), getResources(), addMsg(), renderMsgs(),
+ *                  isLoggedIn(), currentUserId(), templateName()
+ *
+ * Modules (AuthModule today, more in 14c-2…14c-6) populate `pageTitle`
+ * and `pageContent`; the editor template prints them straight through.
+ */
+class Editor
+{
+    public string $siteUrl;
+    public string $themeUrl;
+    public string $version = '2.0.0-dev';
+    public string $pageTitle = 'Scriptor';
+    public string $pageContent = '';
+    public string $breadcrumbs = '';
+    public string $jsConfig = '';
+
+    /** @var list<array{type: string, value: string, header?: string}> */
+    public array $msgs = [];
+
+    public Csrf $csrf;
+    public Request $input;
+    public Sanitizer $sanitizer;
+    public UrlSegments $urlSegments;
+    public TemplateRenderer $templateParser;
+    public SessionStore $session;
+
+    /** @var array<string, mixed> */
+    public array $config;
+
+    /** @var array<string, string> */
+    public array $i18n = [];
+
+    /** @var array{link: list<string>, script: list<string>, script_body: list<string>} */
+    private array $resources = [
+        'link'        => [],
+        'script'      => [],
+        'script_body' => [],
+    ];
+
+    public function __construct(
+        protected Container $container,
+        array $config,
+        protected string $scriptorRoot,
+    ) {
+        $this->config = $config;
+        $this->csrf = $container->get(Csrf::class);
+        $this->session = $container->get(SessionStore::class);
+        $this->input = Request::fromGlobals();
+        $this->sanitizer = new Sanitizer($container->get(ImanagerSanitizer::class));
+        $this->templateParser = new TemplateRenderer();
+
+        $this->siteUrl = self::detectSiteUrl() . '/' . trim((string) $config['admin_path'], '/');
+        $this->themeUrl = $this->siteUrl . '/theme';
+        $this->urlSegments = self::editorSegments($config);
+
+        $this->loadI18n();
+    }
+
+    public function isLoggedIn(): bool
+    {
+        return $this->session->get('loggedin') === true;
+    }
+
+    public function currentUserId(): ?int
+    {
+        $id = $this->session->get('userid');
+        return \is_int($id) ? $id : null;
+    }
+
+    /**
+     * Cookie-based session messages — set by modules during a redirect
+     * cycle so the post-redirect render can show them. Drained by
+     * `renderMsgs()`.
+     */
+    public function addMsg(string $type, string $text, string $header = ''): void
+    {
+        $msg = ['type' => $type, 'value' => $text];
+        if ($header !== '') {
+            $msg['header'] = $header;
+        }
+        $this->msgs[] = $msg;
+    }
+
+    public function renderMsgs(): string
+    {
+        $session = (array) $this->session->get('msgs', []);
+        if ($session !== []) {
+            foreach ($session as $msg) {
+                if (\is_array($msg) && isset($msg['type'], $msg['value'])) {
+                    $this->msgs[] = [
+                        'type'   => (string) $msg['type'],
+                        'value'  => (string) $msg['value'],
+                        'header' => isset($msg['header']) ? (string) $msg['header'] : '',
+                    ];
+                }
+            }
+            $this->session->remove('msgs');
+        }
+
+        if ($this->msgs === []) {
+            return '';
+        }
+        $html = '<ul class="messages">';
+        foreach ($this->msgs as $msg) {
+            $html .= \sprintf(
+                '<li class="msg msg-%s">%s%s</li>',
+                htmlspecialchars($msg['type'], \ENT_QUOTES),
+                isset($msg['header']) && $msg['header'] !== ''
+                    ? '<strong>' . htmlspecialchars($msg['header'], \ENT_QUOTES) . '</strong> '
+                    : '',
+                $msg['value'],
+            );
+        }
+        $html .= '</ul>';
+        $this->msgs = [];
+        return $html;
+    }
+
+    /**
+     * Push a flash message that survives a redirect via session storage.
+     */
+    public function flashMsg(string $type, string $text): void
+    {
+        $bag = (array) $this->session->get('msgs', []);
+        $bag[] = ['type' => $type, 'value' => $text];
+        $this->session->set('msgs', $bag);
+    }
+
+    public function getProperty(string $name): mixed
+    {
+        return match ($name) {
+            'pageTitle'   => $this->pageTitle,
+            'pageContent' => $this->pageContent,
+            'breadcrumbs' => $this->breadcrumbs,
+            'jsConfig'    => $this->jsConfig,
+            'messages'    => $this->renderMsgs(),
+            default       => null,
+        };
+    }
+
+    /**
+     * Module-supplied <link>/<script> tags. `position` decides whether
+     * the tag goes into <head> or just before </body>.
+     */
+    public function addResource(string $kind, string $html, string $position = 'head'): void
+    {
+        $key = $kind === 'script' && $position === 'body' ? 'script_body' : $kind;
+        if (! isset($this->resources[$key])) {
+            return;
+        }
+        $this->resources[$key][] = $html;
+    }
+
+    public function getResources(string $kind, string $position = 'head'): string
+    {
+        $key = $kind === 'script' && $position === 'boddy' ? 'script_body' : $kind;
+        $key = $kind === 'script' && $position === 'body'  ? 'script_body' : $key;
+        return implode("\n", $this->resources[$key] ?? []);
+    }
+
+    public function templateName(string $value): string
+    {
+        return $this->sanitizer->templateName($value);
+    }
+
+    /**
+     * `tokenName=…&tokenValue=…` ready for appending to a logout/GET URL.
+     * Replaces 1.x `$csrf->renderUrl()` shape consumed by editor/theme/header.php.
+     */
+    public function csrfQueryString(string $name = 'logout_token'): string
+    {
+        $value = $this->csrf->token($name);
+        return '?tokenName=' . rawurlencode($name) . '&tokenValue=' . rawurlencode($value);
+    }
+
+    private function loadI18n(): void
+    {
+        $lang = (string) ($this->config['lang'] ?? 'en_US');
+        $file = $this->scriptorRoot . '/' . trim((string) $this->config['admin_path'], '/') . '/lang/' . $lang . '.php';
+        if (! is_file($file)) {
+            return;
+        }
+        $i18n = [];
+        require $file;
+        if (\is_array($i18n)) {
+            /** @var array<string, string> $i18n */
+            $this->i18n = $i18n;
+        }
+    }
+
+    private static function editorSegments(array $config): UrlSegments
+    {
+        $admin = trim((string) $config['admin_path'], '/');
+        $uri   = $_SERVER['REQUEST_URI'] ?? '/';
+        // Strip the editor mount-point so `/editor/auth/logout/` parses
+        // into segments [auth, logout].
+        $path = parse_url($uri, \PHP_URL_PATH) ?? '/';
+        if ($admin !== '' && str_starts_with($path, '/' . $admin)) {
+            $path = substr($path, \strlen($admin) + 1);
+        }
+        if ($path === '' || $path[0] !== '/') {
+            $path = '/' . $path;
+        }
+        return UrlSegments::fromPath($path);
+    }
+
+    private static function detectSiteUrl(): string
+    {
+        $scheme = (! empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+        $host   = $_SERVER['HTTP_HOST'] ?? 'localhost';
+        return $scheme . '://' . $host;
+    }
+}

--- a/boot/Editor/EditorRouter.php
+++ b/boot/Editor/EditorRouter.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Editor;
+
+use League\Container\Container;
+use Scriptor\Boot\Editor\Auth\AuthModule;
+use Scriptor\Boot\Editor\Auth\LoginAttempts;
+
+/**
+ * Phase 14c-1 router: dispatches the editor URL to the right module.
+ *
+ * Active modules:
+ *   - auth (login/logout) — built on iManager 2.0 Csrf + Request +
+ *     SessionStore + PasswordFieldType-hashed credentials.
+ *
+ * Anything else (pages/users/settings/install/profile) returns a
+ * placeholder page until its sub-phase ships. The placeholder is
+ * intentional: the editor stays reachable end-to-end on this branch
+ * for smoke-testing the auth flow without 1.x fallbacks.
+ *
+ * Auth gating:
+ *   - the auth module itself is always reachable (anonymous login form);
+ *   - everything else requires `$editor->isLoggedIn()` and 302's to
+ *     /editor/auth/ otherwise.
+ */
+final class EditorRouter
+{
+    private const PLACEHOLDER_MODULES = [
+        'pages'    => '14c-2',
+        'profile'  => '14c-6',
+        'settings' => '14c-4',
+        'install'  => '14c-5',
+        'users'    => '14c-3',
+    ];
+
+    public function __construct(
+        private readonly Editor $editor,
+        private readonly Container $container,
+    ) {}
+
+    public function execute(): void
+    {
+        $first = $this->editor->urlSegments->first();
+
+        if ($first === 'auth' || ($first === null && ! $this->editor->isLoggedIn())) {
+            $this->dispatchAuth();
+            return;
+        }
+
+        if (! $this->editor->isLoggedIn()) {
+            $this->redirect($this->editor->siteUrl . '/auth/');
+        }
+
+        if ($first === null) {
+            $this->renderDashboard();
+            return;
+        }
+
+        if (isset(self::PLACEHOLDER_MODULES[$first])) {
+            $this->renderPlaceholder($first, self::PLACEHOLDER_MODULES[$first]);
+            return;
+        }
+
+        $this->renderUnknownModule($first);
+    }
+
+    private function dispatchAuth(): void
+    {
+        $auth = new AuthModule(
+            $this->editor,
+            new UserRepository(
+                $this->container->get(\Imanager\Storage\CategoryRepository::class),
+                $this->container->get(\Imanager\Storage\ItemRepository::class),
+            ),
+            new LoginAttempts(
+                $this->editor->session,
+                maxAttempts: (int) ($this->editor->config['maxFailedAccessAttempts'] ?? 5),
+                lockoutMinutes: (int) ($this->editor->config['accessLockoutDuration'] ?? 5),
+            ),
+        );
+        $auth->execute();
+    }
+
+    private function renderDashboard(): void
+    {
+        $this->editor->pageTitle = 'Dashboard - Scriptor';
+        $this->editor->pageContent =
+            '<h1>' . htmlspecialchars($this->editor->i18n['dashboard_menu'] ?? 'Dashboard', \ENT_QUOTES) . '</h1>'
+            . '<p>iManager 2.0 editor — Phase 14c-1 (auth) is live. '
+            . 'Other admin modules come back online with their own sub-phase.</p>'
+            . $this->placeholderModuleList();
+    }
+
+    private function renderPlaceholder(string $module, string $phase): void
+    {
+        $this->editor->pageTitle = ucfirst($module) . ' (coming soon) - Scriptor';
+        $this->editor->pageContent =
+            '<h1>' . htmlspecialchars(ucfirst($module), \ENT_QUOTES) . '</h1>'
+            . '<p>The <strong>' . htmlspecialchars($module, \ENT_QUOTES) . '</strong> module '
+            . 'will be reattached in phase <code>' . htmlspecialchars($phase, \ENT_QUOTES) . '</code>.</p>'
+            . $this->placeholderModuleList();
+    }
+
+    private function renderUnknownModule(string $module): void
+    {
+        http_response_code(404);
+        $this->editor->pageTitle = 'Module not found';
+        $this->editor->pageContent =
+            '<h1>404</h1>'
+            . '<p>Module <code>' . htmlspecialchars($module, \ENT_QUOTES) . '</code> is not available.</p>';
+    }
+
+    private function placeholderModuleList(): string
+    {
+        $items = '';
+        foreach (self::PLACEHOLDER_MODULES as $slug => $phase) {
+            $items .= \sprintf(
+                '<li><code>%s</code> — %s</li>',
+                htmlspecialchars($slug, \ENT_QUOTES),
+                htmlspecialchars($phase, \ENT_QUOTES),
+            );
+        }
+        return '<h2>Phase 14c roadmap</h2><ul>' . $items . '</ul>';
+    }
+
+    private function redirect(string $url): never
+    {
+        header('Location: ' . $url, true, 302);
+        exit;
+    }
+}

--- a/boot/Editor/UserRepository.php
+++ b/boot/Editor/UserRepository.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Editor;
+
+use Imanager\Domain\Item;
+use Imanager\Query\Operator;
+use Imanager\Query\Query;
+use Imanager\Storage\CategoryRepository;
+use Imanager\Storage\ItemRepository;
+
+/**
+ * Read access to the Users category for the editor's auth/profile flows.
+ *
+ * The Users category is created during the legacy Scriptor install
+ * (slug = `users`); items hold `name`, plus field values for
+ * `password` (bcrypt hash from PasswordFieldType), `email` and `role`.
+ */
+final readonly class UserRepository
+{
+    public int $categoryId;
+
+    public function __construct(
+        private CategoryRepository $categories,
+        private ItemRepository $items,
+        string $categorySlug = 'users',
+    ) {
+        $category = $this->categories->findBySlug($categorySlug);
+        if ($category === null || $category->id === null) {
+            throw new \RuntimeException(\sprintf(
+                'Category with slug "%s" not found in the iManager database',
+                $categorySlug,
+            ));
+        }
+        $this->categoryId = $category->id;
+    }
+
+    public function find(int $id): ?Item
+    {
+        $user = $this->items->find($id);
+        return $user !== null && $user->categoryId === $this->categoryId ? $user : null;
+    }
+
+    public function findByName(string $name): ?Item
+    {
+        $query = (new Query($this->categoryId))
+            ->where('name', Operator::Eq, $name)
+            ->limit(1);
+        foreach ($this->items->query($query) as $user) {
+            return $user;
+        }
+        return null;
+    }
+}

--- a/boot/ImanagerBootstrap.php
+++ b/boot/ImanagerBootstrap.php
@@ -26,6 +26,9 @@ use Imanager\Field\Types\TextFieldType;
 use Imanager\Files\FileStorage;
 use Imanager\Files\ImageProcessor;
 use Imanager\Files\LocalFileStorage;
+use Imanager\Http\Csrf;
+use Imanager\Http\NativeSessionStore;
+use Imanager\Http\SessionStore;
 use Imanager\Search\FullTextSearch;
 use Imanager\Storage\CategoryRepository;
 use Imanager\Storage\FieldRepository;
@@ -105,6 +108,11 @@ final class ImanagerBootstrap
 
         $container->addShared(ImageProcessor::class, static fn(): ImageProcessor
             => ImageProcessor::default());
+
+        $container->addShared(SessionStore::class, static fn(): SessionStore
+            => new NativeSessionStore('scriptor'));
+        $container->addShared(Csrf::class, static fn(): Csrf
+            => new Csrf($container->get(SessionStore::class), maxTokens: 10));
 
         $container->addShared(FieldTypeRegistry::class, static function () use ($container): FieldTypeRegistry {
             $registry = new FieldTypeRegistry();

--- a/editor/index.php
+++ b/editor/index.php
@@ -1,1 +1,21 @@
-<?php include __DIR__.'/core/_inc.php' ; ?>
+<?php
+
+declare(strict_types=1);
+
+use Scriptor\Boot\App;
+use Scriptor\Boot\Editor\Editor;
+use Scriptor\Boot\Editor\EditorRouter;
+
+require_once __DIR__ . '/../boot.php';
+
+if (! isset($_SESSION)) {
+    session_name('IMSESSID');
+    session_start();
+}
+
+/** @var array<string, mixed> $config */
+$editor = new Editor(App::container(), $config, dirname(__DIR__));
+$router = new EditorRouter($editor, App::container());
+$router->execute();
+
+include __DIR__ . '/theme/template.php';

--- a/editor/theme/header.php
+++ b/editor/theme/header.php
@@ -1,6 +1,9 @@
-<?php defined('IS_IM') or die('You cannot access this page directly');
+<?php declare(strict_types=1);
 
-if(isset($_SESSION['loggedin'])) { ?>
+if (! $editor->isLoggedIn()) {
+    return;
+}
+?>
 <header class="arounder">
 	<ul class="guillotine">
 		<li><a id="trigger" href="#"><span class="gg-menu"></span></a></li>
@@ -9,18 +12,23 @@ if(isset($_SESSION['loggedin'])) { ?>
 		<?php echo $editor->getProperty('breadcrumbs'); ?>
 	</ul>
 	<ul class="profile">
-	<?php if($editor->config['modules']) {
-		foreach($editor->config['modules'] as $slug => $module) {
-			if($module['active'] && in_array('profile', $module['display_type'])) { ?><li<?php 
-			echo(($imanager->input->urlSegments->get(0) == $slug) ? ' class="active" ' : '');
-				?>><a href="<?php echo $editor->siteUrl.'/'.$slug.'/'.(($module['menu'] == 'logout_menu') ?
-					'logout/'.$editor->csrf->renderUrl() : ''); ?>"><i class="<?php echo $module['icon'] ?>"></i><span><?php
-						echo (isset($editor->i18n[$module['menu']])) ? $editor->i18n[$module['menu']] : $module['menu'];
-						?></span></a></li>
-		<?php	}
-			}
-		}
-		?>
+<?php
+$activeSlug = $editor->urlSegments->first() ?? '';
+foreach ((array) ($editor->config['modules'] ?? []) as $slug => $module) {
+    if (
+        empty($module['active'])
+        || ! \is_array($module['display_type'] ?? null)
+        || ! \in_array('profile', $module['display_type'], true)
+    ) {
+        continue;
+    }
+    $isLogout = ($module['menu'] ?? '') === 'logout_menu';
+    $href = $editor->siteUrl . '/' . $slug . '/' . ($isLogout ? 'logout/' . $editor->csrfQueryString() : '');
+    $label = $editor->i18n[$module['menu']] ?? (string) $module['menu'];
+    $icon  = (string) ($module['icon'] ?? '');
+    $cls   = $activeSlug === $slug ? ' class="active"' : '';
+?>
+		<li<?= $cls ?>><a href="<?= htmlspecialchars($href, ENT_QUOTES) ?>"><i class="<?= htmlspecialchars($icon, ENT_QUOTES) ?>"></i><span><?= htmlspecialchars($label, ENT_QUOTES) ?></span></a></li>
+<?php } ?>
 	</ul>
 </header>
-<?php } ?>

--- a/editor/theme/summary.php
+++ b/editor/theme/summary.php
@@ -1,28 +1,32 @@
-<?php defined('IS_IM') or die('You cannot access this page directly'); ?>
+<?php declare(strict_types=1); ?>
 <div class="summary-wrapper">
 	<span class="close"><i class="gg-close"></i></span>
 	<nav role="navigation">
 		<div class="brand-wrapper">
-			<a href="<?php echo $editor->siteUrl; ?>"><img alt="logo" width="200" src="<?php echo $editor->siteUrl; ?>/theme/images/logo.svg"></a>
+			<a href="<?php echo htmlspecialchars($editor->siteUrl, ENT_QUOTES); ?>"><img alt="logo" width="200" src="<?php echo htmlspecialchars($editor->siteUrl, ENT_QUOTES); ?>/theme/images/logo.svg"></a>
 		</div>
-		<?php if(isset($_SESSION['loggedin'])) { ?>
+<?php if ($editor->isLoggedIn()): ?>
 		<ul class="summary">
-			<?php if($editor->config['modules']) {
-				foreach($editor->config['modules'] as $slug => $module) {
-					if($module['active'] && in_array('sidebar', $module['display_type'])) {
-						?>
-						<li class="chapter<?php echo(($imanager->input->urlSegments->get(0) == $slug) ? ' active' : ''); ?>"
-							data-level="1.1" data-path="./">
-							<a href="<?php echo $editor->siteUrl.'/'.$slug; ?>/"><?php echo (isset($module['icon']) && !empty($module['icon'])) ? 
-								'<i class="'.$module['icon'].'"></i>' : ''; ?><span><?php echo (isset($editor->i18n[$module['menu']])) ? 
-								$editor->i18n[$module['menu']] : $module['menu']; ?></span></a>
-						</li>
-						<?php
-					}
-				}
-			?>
-			<?php } ?>
+<?php
+$activeSlug = $editor->urlSegments->first() ?? '';
+foreach ((array) ($editor->config['modules'] ?? []) as $slug => $module) {
+    if (
+        empty($module['active'])
+        || ! \is_array($module['display_type'] ?? null)
+        || ! \in_array('sidebar', $module['display_type'], true)
+    ) {
+        continue;
+    }
+    $href  = $editor->siteUrl . '/' . $slug . '/';
+    $label = $editor->i18n[$module['menu']] ?? (string) $module['menu'];
+    $icon  = (string) ($module['icon'] ?? '');
+    $cls   = 'chapter' . ($activeSlug === $slug ? ' active' : '');
+?>
+			<li class="<?= htmlspecialchars($cls, ENT_QUOTES) ?>" data-level="1.1" data-path="./">
+				<a href="<?= htmlspecialchars($href, ENT_QUOTES) ?>"><?= $icon !== '' ? '<i class="' . htmlspecialchars($icon, ENT_QUOTES) . '"></i>' : '' ?><span><?= htmlspecialchars($label, ENT_QUOTES) ?></span></a>
+			</li>
+<?php } ?>
 		</ul>
-		<?php } ?>
+<?php endif; ?>
 	</nav>
 </div>

--- a/editor/theme/template.php
+++ b/editor/theme/template.php
@@ -1,4 +1,7 @@
-<?php defined('IS_IM') or die('You cannot access this page directly'); ?>
+<?php
+declare(strict_types=1);
+isset($editor) or die('You cannot access this page directly');
+?>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -32,8 +35,7 @@
 	</div>
 	<footer role="contentinfo">
 		<div>
-			<a href="https://scriptor-cms.info">Scriptor</a> <?php echo
-				Scriptor\Core\Scriptor::VERSION; ?> &copy; <time datetime="<?php echo date('Y'); ?>"><?php echo date('Y'); ?></time>
+			<a href="https://scriptor-cms.info">Scriptor</a> <?php echo htmlspecialchars($editor->version, ENT_QUOTES); ?> &copy; <time datetime="<?php echo date('Y'); ?>"><?php echo date('Y'); ?></time>
 		</div>
 	</footer>
 </main>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                             
  The /editor/ admin shell now boots through a brand-new                                                                                                                                                                                                                                                                                                                                   
  `Scriptor\Boot\Editor\` namespace on the iManager 2.0 container —                                                                                                                                                                                                                                                                                                                        
  no calls into the legacy `Scriptor::build()` / `editor/core/` path                                                                                                                                                                                                                                                                                                                       
  on the public auth flow.                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                           
  - **Editor\Editor** — surface for theme/template.php (siteUrl, themeUrl,                                                                                                                                                                                                                                                                                                                 
    version, csrf, msgs, pageTitle, pageContent, breadcrumbs, jsConfig,                                                                                                                                                                                                                                                                                                                    
    i18n, sanitizer, urlSegments, session). Loads legacy `lang/<lang>.php`                                                                                                                                                                                                                                                                                                                 
    verbatim.                                                                                                                                                                                                                                                                                                                                                                              
  - **Editor\EditorRouter** — routes `/editor/<module>/<action>`; auth is                                                                                                                                                                                                                                                                                                                  
    live, every other slug returns a typed "coming back in 14c-N"                                                                                                                                                                                                                                                                                                                          
    placeholder so the branch stays end-to-end testable until the                                                                                                                                                                                                                                                                                                                          
    remaining modules ship.                                                                                                                                                                                                                                                                                                                                                                
  - **Editor\UserRepository** — thin lookup over CategoryRepository +                                                                                                                                                                                                                                                                                                                      
    ItemRepository for the Users category.                                                                                                                                                                                                                                                                                                                                                 
  - **Editor\Auth\AuthModule** — login form + login/logout handlers on                                                                                                                                                                                                                                                                                                                     
    `Imanager\Http\Csrf`, Request, SessionStore. Verifies bcrypt hashes                                                                                                                                                                                                                                                                                                                    
    via `password_verify()`; accepts both the new plain-string password                                                                                                                                                                                                                                                                                                                    
    field and the migrated 1.x `{__class, password, salt}` wrapper.                                                                                                                                                                                                                                                                                                                        
  - **Editor\Auth\LoginAttempts** — session-scoped IP lockout                                                                                                                                                                                                                                                                                                                              
    (`maxFailedAccessAttempts` / `accessLockoutDuration` from                                                                                                                                                                                                                                                                                                                              
    scriptor-config).                                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                           
  Bootstrap: `ImanagerBootstrap` registers `NativeSessionStore` (namespaced                                                                                                                                                                                                                                                                                                                
  `scriptor`) and `Csrf` (maxTokens=10).                                                                                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                                           
  Editor entry / theme: `editor/index.php`'s 1-line legacy include                                                                                                                                                                                                                                                                                                                         
  replaced by an explicit `require boot.php` + new Editor + EditorRouter.                                                                                                                                                                                                                                                                                                                  
  `editor/theme/{template,header,summary}.php` trimmed: drop the 1.x                                                                                                                                                                                                                                                                                                                       
  `IS_IM` define, drop `\Scriptor\Core\Scriptor::VERSION`, switch the                                                                                                                                                                                                                                                                                                                      
  profile/sidebar menus to the new `$editor` surface (`isLoggedIn()`,                                                                                                                                                                                                                                                                                                                      
  `urlSegments`, `csrfQueryString()`).                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                           
  CSRF: every login POST and logout GET must carry a token; failures                                                                                                                                                                                                                                                                                                                       
  flash a translated `error_csrf_token_mismatch` error.                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                           
  ## Test plan                                                                                                                                                                                                                                                                                                                                                                             
  - [x] `GET /editor/auth/` → 200, login form, CSRF token len=64                                                                                                                                                                                                                                                                                                                           
  - [x] `POST /editor/auth/` wrong creds → 200, error msg, attempts++                                                                                                                                                                                                                                                                                                                      
  - [x] `POST /editor/auth/` admin / `gT5nLazzyBob` → 302 → /editor/                                                                                                                                                                                                                                                                                                                       
  - [x] `GET /editor/` (auth) → 200 dashboard with sidebar                                                                                                                                                                                                                                                                                                                                 
  - [x] `GET /editor/pages` → 200 placeholder (14c-2)                                                                                                                                                                                                                                                                                                                                      
  - [x] `GET /editor/auth/logout/?tokenName=…&tokenValue=…` → 302 → /editor/auth/                                                                                                                                                                                                                                                                                                          
  - [x] `GET /editor/` after logout → 200 login form                                                                                                                                                                                                                                                                                                                                       
  - [ ] Browser smoke against ServBay