### PR TITLE
fix(routing): single-entry router so /editor/* works on Caddy/Nginx

### DIFF
--- a/index.php
+++ b/index.php
@@ -8,6 +8,18 @@ use Scriptor\Boot\Frontend\Site;
 require_once __DIR__ . '/boot.php';
 
 /** @var array<string, mixed> $config */
+$adminPath = trim((string) ($config['admin_path'] ?? 'editor/'), '/');
+$path = parse_url($_SERVER['REQUEST_URI'] ?? '/', \PHP_URL_PATH) ?? '/';
+
+// Single-entry router: hand off /<admin_path>/* requests to the editor
+// entry. Keeps the site working on web servers that route everything
+// through index.php (Caddy default snippet, php -S) without depending
+// on .htaccess-style rewrites being honoured.
+if ($path === '/' . $adminPath || str_starts_with($path, '/' . $adminPath . '/')) {
+    require __DIR__ . '/' . $adminPath . '/index.php';
+    return;
+}
+
 $themeDir = __DIR__ . '/site/themes/' . $config['theme_path'];
 $ext      = $themeDir . '_ext.php';
 


### PR DESCRIPTION
ServBay (and any Caddy/Nginx setup) ignores the legacy .htaccess that splits requests between root index.php and editor/index.php. With only the default `try_files` snippet active, every request (including /editor/*) lands on root index.php, the Frontend\Site doesn't know the slug, and the user gets a 404.

Apache had two RewriteRules; everywhere else only had the second. Make the routing platform-independent by delegating /<admin_path>/* requests from root index.php to editor/index.php on PHP level. editor/index.php keeps working as a standalone entry too, so an Apache rewrite rule (or a direct call) still resolves it.

Smoke (PHP built-in server, behaves like Caddy here):
  GET /                                 200
  GET /articles/                        200
  GET /editor/                          200 (login form)
  GET /editor/auth/                     200
  GET /editor/pages                     200 (was 404 on Caddy)
  GET /editor/pages/                    200
  GET /editor/pages/edit/?page=3        200