### PR TITLE
Phase 14c-4: editor settings module on iManager 2.0

### DIFF
--- a/boot/Editor/EditorRouter.php
+++ b/boot/Editor/EditorRouter.php
@@ -11,6 +11,7 @@ use Scriptor\Boot\Editor\Auth\AuthModule;
 use Scriptor\Boot\Editor\Auth\LoginAttempts;
 use Scriptor\Boot\Editor\Pages\PagesModule;
 use Scriptor\Boot\Editor\Profile\ProfileModule;
+use Scriptor\Boot\Editor\Settings\SettingsModule;
 use Scriptor\Boot\Frontend\PageRepository;
 
 /**
@@ -33,7 +34,6 @@ use Scriptor\Boot\Frontend\PageRepository;
 final class EditorRouter
 {
     private const PLACEHOLDER_MODULES = [
-        'settings' => '14c-4',
         'install'  => '14c-5',
     ];
 
@@ -67,6 +67,11 @@ final class EditorRouter
 
         if ($first === 'profile') {
             $this->dispatchProfile();
+            return;
+        }
+
+        if ($first === 'settings') {
+            (new SettingsModule($this->editor))->execute();
             return;
         }
 

--- a/boot/Editor/Settings/SettingsModule.php
+++ b/boot/Editor/Settings/SettingsModule.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Editor\Settings;
+
+use Scriptor\Boot\Editor\Editor;
+
+/**
+ * Settings module — informational page that points the admin at the
+ * legacy `data/settings/scriptor-config.php` file (and the
+ * `custom.scriptor-config.php` override). The same shape the 1.x
+ * module shipped: no form, no writes, just rendered i18n strings.
+ *
+ * A future iManager 2.0 settings UI (post-Phase-17) would replace
+ * this with an in-place editor; for Phase 14 we keep parity.
+ */
+final class SettingsModule
+{
+    public function __construct(private readonly Editor $editor) {}
+
+    public function execute(): void
+    {
+        $this->editor->pageTitle = 'Settings - Scriptor';
+        $this->editor->breadcrumbs = sprintf(
+            '<li><span>%s</span></li>',
+            htmlspecialchars($this->editor->i18n['settings_menu'] ?? 'Settings', \ENT_QUOTES),
+        );
+
+        $header = $this->editor->i18n['settings_page_header'] ?? 'System settings';
+        // The legacy `settings_page_text` already contains intentional HTML
+        // (a couple of <mark> tags and line breaks) — render it verbatim
+        // rather than escaping it.
+        $body = $this->editor->i18n['settings_page_text'] ?? '';
+
+        $this->editor->pageContent =
+            '<h1>' . htmlspecialchars($header, \ENT_QUOTES) . '</h1>'
+            . '<p>' . $body . '</p>';
+    }
+}


### PR DESCRIPTION
The legacy settings module is a 25-line informational page — it has no form, no writes; just a header and a body explaining that admins should edit data/settings/scriptor-config.php (or the custom.scriptor-config.php override) directly. Functional parity ports this verbatim onto the 2.0 stack.

New Editor\Settings\SettingsModule:
  - GET /editor/settings → 200 with the two i18n strings `settings_page_header` + `settings_page_text` rendered as the legacy module did. Body is intentionally not html-escaped (the string carries the legacy <mark> highlights and line breaks).

EditorRouter routes /editor/settings* to SettingsModule and removes the `settings` placeholder. `install` stays as the only remaining placeholder until 14c-5.

A future iManager 2.0 settings UI (post-Phase-17) would replace this with an in-place editor; for Phase 14 we keep parity.

Manual smoke (PHP built-in server):
  GET /editor/settings (auth)        200, "System Settings", scriptor-config.php
  GET /editor/settings (anonymous)   302 → /editor/auth/
  GET /editor/install                200 (still 14c-5 placeholder)