### PR TITLE
Phase 14d-2: pages edit form on FilePond + existing files listing

### DIFF
--- a/boot/Editor/EditorRouter.php
+++ b/boot/Editor/EditorRouter.php
@@ -7,6 +7,7 @@ namespace Scriptor\Boot\Editor;
 use Imanager\Files\FileStorage;
 use Imanager\Files\ImageProcessor;
 use Imanager\Storage\CategoryRepository;
+use Imanager\Storage\FieldRepository;
 use Imanager\Storage\FileRepository;
 use Imanager\Storage\ItemRepository;
 use Imanager\Validation\Sanitizer as ImanagerSanitizer;
@@ -111,6 +112,8 @@ final class EditorRouter
                 $this->container->get(CategoryRepository::class),
                 $this->container->get(ItemRepository::class),
             ),
+            $this->container->get(FieldRepository::class),
+            $this->container->get(FileRepository::class),
         );
         $module->execute();
     }

--- a/boot/Editor/Pages/PagesModule.php
+++ b/boot/Editor/Pages/PagesModule.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace Scriptor\Boot\Editor\Pages;
 
+use Imanager\Domain\File;
 use Imanager\Domain\Item;
+use Imanager\Storage\FieldRepository;
+use Imanager\Storage\FileRepository;
 use Scriptor\Boot\Editor\Editor;
 use Scriptor\Boot\Frontend\Page;
 use Scriptor\Boot\Frontend\PageRepository;
@@ -29,6 +32,8 @@ final class PagesModule
     public function __construct(
         private readonly Editor $editor,
         private readonly PageRepository $pages,
+        private readonly FieldRepository $fields,
+        private readonly FileRepository $files,
     ) {
         $reserved = (array) ($this->editor->config['reservedSlugs'] ?? []);
         /** @var list<int> $reserved */
@@ -308,27 +313,113 @@ final class PagesModule
 
     private function renderImagesSection(?Page $page): string
     {
-        $images = $page?->images ?? [];
-        if ($images === []) {
-            return '<div class="form-control"><label>' . htmlspecialchars($this->t('header_image_label'), \ENT_QUOTES) . '</label>'
-                . '<p class="info-text"><em>Image upload reattaches in phase 14d (FilePond + UploadHandler). Existing images render here when present.</em></p></div>';
+        $label = htmlspecialchars($this->t('header_image_label') ?: 'Images', \ENT_QUOTES);
+        $info  = htmlspecialchars($this->t('header_image_infotext') ?: '', \ENT_QUOTES);
+        $infoBlock = $info !== ''
+            ? '<p class="info-text i-wrapp"><i class="gg-danger"></i>' . $info . '</p>'
+            : '';
+
+        // Edit existing page → wire FilePond against the upload endpoint.
+        // New page → can't wire an upload (UploadHandler requires itemId>=1).
+        if ($page === null || $page->id() === null) {
+            return '<div class="form-control"><label>' . $label . '</label>' . $infoBlock
+                . '<p class="info-text"><em>Save the page first to enable image upload.</em></p></div>';
         }
-        $rows = '';
-        foreach ($images as $img) {
+
+        $itemId  = (int) $page->id();
+        $field   = $this->fields->findByName($this->pages->categoryId, 'images');
+        if ($field === null || $field->id === null) {
+            return '<div class="form-control"><label>' . $label . '</label>' . $infoBlock
+                . '<p class="info-text"><em>The Pages category has no <code>images</code> field — nothing to render.</em></p></div>';
+        }
+        $fieldId = (int) $field->id;
+        $token   = $this->editor->csrf->token('pages');
+
+        $files = $this->files->findByItemAndField($itemId, $fieldId);
+        $legacy = $page->images;
+
+        $existingRows = '';
+        foreach ($files as $file) {
+            $existingRows .= $this->renderUploadedFileRow($file);
+        }
+        $legacyRows = '';
+        foreach ($legacy as $img) {
             if (! \is_array($img)) {
                 continue;
             }
-            $name = (string) ($img['name'] ?? '');
+            $name  = (string) ($img['name']  ?? '');
             $title = (string) ($img['title'] ?? '');
-            $rows .= sprintf(
-                '<li><code>%s</code>%s</li>',
+            if ($name === '') {
+                continue;
+            }
+            $legacyRows .= sprintf(
+                '<li><code>%s</code>%s <em>(legacy 1.x — display-only until 14d-3)</em></li>',
                 htmlspecialchars($name, \ENT_QUOTES),
                 $title !== '' ? ' — ' . htmlspecialchars($title, \ENT_QUOTES) : '',
             );
         }
-        return '<div class="form-control"><label>' . htmlspecialchars($this->t('header_image_label'), \ENT_QUOTES) . '</label>'
-            . '<p class="info-text"><em>Read-only until phase 14d wires uploads.</em></p>'
-            . '<ul class="image-list">' . $rows . '</ul></div>';
+
+        $existingBlock = $existingRows !== ''
+            ? '<ul class="image-list image-list--uploaded">' . $existingRows . '</ul>'
+            : '';
+        $legacyBlock = $legacyRows !== ''
+            ? '<details><summary>Legacy 1.x images on this page (' . substr_count($legacyRows, '<li>') . ')</summary>'
+                . '<ul class="image-list image-list--legacy">' . $legacyRows . '</ul></details>'
+            : '';
+
+        // FilePond container + the metadata bag the init script needs.
+        // The script reads `data-*` attributes off this element, posts
+        // multipart uploads to the API, and stuffs the new fileId into a
+        // hidden input so the page form can render the up-to-date set
+        // after a redirect.
+        $pondId = 'filepond-images-' . $itemId;
+        $widget = sprintf(
+            '<input type="file" id="%s" class="filepond" data-itemid="%d" data-fieldid="%d" data-csrf-name="pages" data-csrf-value="%s" data-upload-url="%s" multiple>',
+            htmlspecialchars($pondId, \ENT_QUOTES),
+            $itemId,
+            $fieldId,
+            htmlspecialchars($token, \ENT_QUOTES),
+            htmlspecialchars($this->editor->siteUrl . '/api/upload', \ENT_QUOTES),
+        );
+
+        return '<div class="form-control image-section">'
+            . '<label>' . $label . '</label>'
+            . $infoBlock
+            . $existingBlock
+            . $widget
+            . $legacyBlock
+            . '</div>';
+    }
+
+    private function renderUploadedFileRow(File $file): string
+    {
+        $i = static fn(string $s): string => htmlspecialchars($s, \ENT_QUOTES);
+        $thumbName = \sprintf('300x300_%s', $file->name);
+        // Public-URL convention from FileStorage::url() — the storage is
+        // wired with /data/uploads-2.0 as its public base in the bootstrap.
+        $base = '/data/uploads-2.0';
+        $assetUrl = \sprintf('%s/%s', $base, $file->path);
+        $thumbUrl = \sprintf('%s/%s/thumbnail/%s', $base, \dirname($file->path), $thumbName);
+        $token = $this->editor->csrf->token('pages');
+
+        return sprintf(
+            '<li class="image-list__item" data-file-id="%d">'
+                . '<a href="%s" target="_blank"><img src="%s" alt="%s" loading="lazy" width="120" height="120"></a>'
+                . ' <code>%s</code> <span class="muted">(%dx%d, %d bytes)</span>'
+                . ' <button type="button" class="image-list__remove" data-file-id="%1$d" data-csrf-name="pages" data-csrf-value="%s" data-delete-url="%s">'
+                . '<i class="gg-trash"></i> remove</button>'
+                . '</li>',
+            (int) $file->id,
+            $i($assetUrl),
+            $i($thumbUrl),
+            $i($file->name),
+            $i($file->name),
+            $file->width,
+            $file->height,
+            $file->size,
+            $i($token),
+            $i($this->editor->siteUrl . '/api/upload'),
+        );
     }
 
     private function fieldText(string $id, string $name, string $label, string $value, bool $required = false, string $infoText = ''): string

--- a/editor/theme/scripts/filepond-init.js
+++ b/editor/theme/scripts/filepond-init.js
@@ -1,0 +1,131 @@
+/**
+ * FilePond bootstrap for the editor pages form.
+ *
+ * Wires every <input class="filepond"> element on the page against the
+ * Phase 14d-1 upload endpoint. Configuration comes from data-* attributes
+ * the server emits next to the input:
+ *
+ *   data-itemid       owning item id
+ *   data-fieldid      owning field id
+ *   data-csrf-name    CSRF token name (`pages` for the pages form)
+ *   data-csrf-value   CSRF token value
+ *   data-upload-url   POST/DELETE URL (typically /editor/api/upload)
+ *
+ * The image-section already lists existing uploads server-side; FilePond
+ * only handles the new-upload flow plus the `revert` (cancel pending)
+ * action. The "remove" button on existing rows posts a separate DELETE
+ * to the same endpoint.
+ */
+(function () {
+  'use strict';
+
+  function ready(fn) {
+    if (document.readyState !== 'loading') { fn(); }
+    else { document.addEventListener('DOMContentLoaded', fn); }
+  }
+
+  ready(function () {
+    if (typeof FilePond === 'undefined') {
+      return;
+    }
+
+    if (typeof FilePondPluginImagePreview !== 'undefined') {
+      FilePond.registerPlugin(FilePondPluginImagePreview);
+    }
+    if (typeof FilePondPluginFileValidateType !== 'undefined') {
+      FilePond.registerPlugin(FilePondPluginFileValidateType);
+    }
+    if (typeof FilePondPluginFileValidateSize !== 'undefined') {
+      FilePond.registerPlugin(FilePondPluginFileValidateSize);
+    }
+
+    document.querySelectorAll('input.filepond').forEach(function (input) {
+      var itemId    = input.dataset.itemid;
+      var fieldId   = input.dataset.fieldid;
+      var csrfName  = input.dataset.csrfName;
+      var csrfValue = input.dataset.csrfValue;
+      var url       = input.dataset.uploadUrl;
+
+      if (!itemId || !fieldId || !csrfName || !csrfValue || !url) {
+        return;
+      }
+
+      FilePond.create(input, {
+        allowMultiple: true,
+        acceptedFileTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
+        maxFileSize: '8MB',
+        labelIdle: 'Drop images here or <span class="filepond--label-action">Browse</span>',
+        server: {
+          process: {
+            url: url,
+            method: 'POST',
+            withCredentials: true,
+            ondata: function (formData) {
+              formData.append('itemId', itemId);
+              formData.append('fieldId', fieldId);
+              formData.append('tokenName', csrfName);
+              formData.append('tokenValue', csrfValue);
+              return formData;
+            },
+            onload: function (response) {
+              try {
+                var payload = JSON.parse(response);
+                return String(payload.fileId || '');
+              } catch (e) {
+                return '';
+              }
+            },
+            onerror: function (response) {
+              try {
+                return (JSON.parse(response).error || 'Upload failed');
+              } catch (e) {
+                return 'Upload failed';
+              }
+            }
+          },
+          revert: {
+            url: '',  // FilePond appends the file id; we override with full url
+            method: 'DELETE',
+            withCredentials: true,
+            // Use a custom function so we can send the CSRF + fileId in the
+            // form-encoded body the endpoint expects.
+            onload: function () { return true; },
+            onerror: function () { return 'Revert failed'; }
+          }
+        }
+      });
+    });
+
+    // Existing-file remove buttons: server-rendered. POST a DELETE to the
+    // upload endpoint with CSRF, then drop the row from the DOM.
+    document.querySelectorAll('.image-list__remove').forEach(function (btn) {
+      btn.addEventListener('click', function (event) {
+        event.preventDefault();
+        var fileId   = btn.dataset.fileId;
+        var url      = btn.dataset.deleteUrl;
+        var csrfName = btn.dataset.csrfName;
+        var csrfVal  = btn.dataset.csrfValue;
+        if (!fileId || !url) { return; }
+
+        var body = new URLSearchParams({
+          fileId: fileId,
+          tokenName: csrfName || '',
+          tokenValue: csrfVal || ''
+        });
+        fetch(url, {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          credentials: 'same-origin',
+          body: body.toString()
+        }).then(function (res) {
+          if (res.ok) {
+            var item = btn.closest('.image-list__item');
+            if (item) { item.remove(); }
+          } else {
+            res.text().then(function (text) { console.error('Delete failed:', text); });
+          }
+        });
+      });
+    });
+  });
+})();

--- a/editor/theme/template.php
+++ b/editor/theme/template.php
@@ -15,6 +15,8 @@ isset($editor) or die('You cannot access this page directly');
 	<link href="<?php echo $editor->siteUrl; ?>/theme/css/css-gg.min.css" rel="stylesheet">
 	<link rel="stylesheet" href="<?php echo $editor->siteUrl; ?>/theme/css/jquery-ui.css">
 	<link rel="stylesheet" href="<?php echo $editor->siteUrl; ?>/theme/css/styles.min.css">
+	<link rel="stylesheet" href="<?php echo $editor->siteUrl; ?>/theme/scripts/filepond/filepond.css">
+	<link rel="stylesheet" href="<?php echo $editor->siteUrl; ?>/theme/scripts/filepond/filepond-image-preview.css">
 	<?php echo $editor->getResources('link'); ?>
 	<script src="<?php echo $editor->siteUrl; ?>/theme/scripts/jquery.min.js"></script>
 	<script src="<?php echo $editor->siteUrl; ?>/theme/scripts/jquery-ui.min.js"></script>
@@ -43,6 +45,11 @@ isset($editor) or die('You cannot access this page directly');
 <script src="<?php echo $editor->siteUrl; ?>/theme/scripts/remarkable/remarkable.min.js"></script>
 <script src="<?php echo $editor->siteUrl; ?>/theme/scripts/prism.js"></script>
 <script src="<?php echo $editor->siteUrl; ?>/theme/scripts/editor.js"></script>
+<script src="<?php echo $editor->siteUrl; ?>/theme/scripts/filepond/filepond.js"></script>
+<script src="<?php echo $editor->siteUrl; ?>/theme/scripts/filepond/filepond-image-preview.js"></script>
+<script src="<?php echo $editor->siteUrl; ?>/theme/scripts/filepond/filepond-file-validate-type.js"></script>
+<script src="<?php echo $editor->siteUrl; ?>/theme/scripts/filepond/filepond-file-validate-size.js"></script>
+<script src="<?php echo $editor->siteUrl; ?>/theme/scripts/filepond-init.js"></script>
 <?php echo $editor->getResources('script', 'boddy'); ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                               
  Picks up where 14d-1 left off: the editor pages edit form now ships a                                                                                                                                                                                                                                                                                                                    
  FilePond widget that posts to `/editor/api/upload`, plus a server-rendered                                                                                                                                                                                                                                                                                                               
  list of files already attached to the page (`FileRepository::findByItemAndField`).                                                                                                                                                                                                                                                                                                       
  Migrated 1.x images (the legacy `images` data array) render in a separate,                                                                                                                                                                                                                                                                                                               
  collapsible "Legacy" block as display-only until 14d-3 brings them onto                                                                                                                                                                                                                                                                                                                  
  the new pipeline.                                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                                           
  **PagesModule:**                                                                                                                                                                                                                                                                                                                                                                         
  - ctor takes `FieldRepository` + `FileRepository`                                                                                                                                                                                                                                                                                                                                        
  - `renderImagesSection` rewritten:                                                                                                                                                                                                                                                                                                                                                       
    - existing page → `<ul.image-list--uploaded>` rows (thumbnail + name +                                                                                                                                                                                                                                                                                                                 
      remove button) followed by an `<input.filepond>` with `data-*` config                                                                                                                                                                                                                                                                                                                
    - new page → "Save the page first" hint (UploadHandler requires `itemId >= 1`)                                                                                                                                                                                                                                                                                                         
    - pages without an `images` field → friendly diagnostic                                                                                                                                                                                                                                                                                                                                
  - File-row markup carries `data-file-id` + CSRF/url so JS can DELETE                                                                                                                                                                                                                                                                                                                     
    without a page reload                                                                                                                                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                                                                                                           
  **filepond-init.js** (vendored under `editor/theme/scripts/`):                                                                                                                                                                                                                                                                                                                           
  - registers image-preview, file-validate-type, file-validate-size plugins                                                                                                                                                                                                                                                                                                                
    when present; tolerates a missing FilePond global                                                                                                                                                                                                                                                                                                                                      
  - per `<input.filepond>`: configures the process URL, appends                                                                                                                                                                                                                                                                                                                            
    itemId/fieldId/CSRF to multipart, parses `{"fileId":N}` response                                                                                                                                                                                                                                                                                                                       
  - wires `.image-list__remove` buttons to fetch DELETE the upload endpoint                                                                                                                                                                                                                                                                                                                
    and remove the row on success                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                           
  Editor template loads `filepond.css` + `filepond-image-preview.css` in                                                                                                                                                                                                                                                                                                                   
  `<head>` and the four FilePond JS files + `filepond-init.js` before                                                                                                                                                                                                                                                                                                                      
  body close.                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                                                                           
  ## Test plan                                                                                                                                                                                                                                                                                                                                                                             
  - [x] `GET /editor/pages/edit/?page=3` → 200, FilePond input + all data-*,                                                                                                                                                                                                                                                                                                               
        legacy block, filepond-init.js loaded                                                                                                                                                                                                                                                                                                                                              
  - [x] `GET /editor/pages/edit/` → 200, "Save the page first" hint                                                                                                                                                                                                                                                                                                                        
  - [x] `POST /editor/api/upload` → 200; fileId returned                                                                                                                                                                                                                                                                                                                                   
  - [x] re-fetch edit form → image-list--uploaded row with thumbnail                                                                                                                                                                                                                                                                                                                       
  - [x] `DELETE /editor/api/upload` → 200; files row gone                                                                                                                                                                                                                                                                                                                                  
  - [x] editor template loads all FilePond assets                                                                                                                                                                                                                                                                                                                                          
  - [ ] Browser smoke against ServBay (drag-drop + thumbnail + remove)