### PR TITLE
fix(upload): align FilePond multipart field name with the endpoint

### DIFF
--- a/boot/Editor/Api/UploadEndpoint.php
+++ b/boot/Editor/Api/UploadEndpoint.php
@@ -72,9 +72,12 @@ final class UploadEndpoint
             $this->error(400, 'itemId and fieldId are required (>= 1)');
         }
 
-        $entry = $this->editor->input->file('file');
+        // Accept either the explicit `file` field we tell FilePond to use
+        // or its default `filepond` field name, so cURL smokes and other
+        // multipart clients keep working without configuration.
+        $entry = $this->editor->input->file('file') ?? $this->editor->input->file('filepond');
         if ($entry === null) {
-            $this->error(400, 'No `file` field on the upload');
+            $this->error(400, 'Upload missing `file` (or `filepond`) field');
         }
 
         try {

--- a/editor/theme/scripts/filepond-init.js
+++ b/editor/theme/scripts/filepond-init.js
@@ -51,6 +51,10 @@
       }
 
       FilePond.create(input, {
+        // Form field name used for the uploaded blob in the multipart
+        // request. Default is "filepond"; we use "file" so the upload
+        // endpoint stays aligned with the cURL smoke fixtures.
+        name: 'file',
         allowMultiple: true,
         acceptedFileTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
         maxFileSize: '8MB',


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                               
  FilePond's default multipart field name is `filepond`. The endpoint                                                                                                                                                                                                                                                                                                                      
  shipped in 14d-1 only looked for `file`, so every browser upload through                                                                                                                                                                                                                                                                                                                 
  the FilePond widget came back as HTTP 400 "No `file` field on the                                                                                                                                                                                                                                                                                                                        
  upload" — even though the cURL smoke (which uses `-F file=@…`) kept                                                                                                                                                                                                                                                                                                                      
  passing.                                                                                                                                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                           
  Two-sided fix:                                                                                                                                                                                                                                                                                                                                                                           
  - `filepond-init.js` sets `name: 'file'` on `FilePond.create()` options,                                                                                                                                                                                                                                                                                                                 
    so future client-side changes can't drift again.                                                                                                                                                                                                                                                                                                                                       
  - `UploadEndpoint::handlePost()` reads `file` first and falls back to                                                                                                                                                                                                                                                                                                                    
    `filepond` so existing FilePond clients without the explicit name                                                                                                                                                                                                                                                                                                                      
    config (3rd-party themes, older builds) keep working too.                                                                                                                                                                                                                                                                                                                              
  - 400 message updated to "Upload missing `file` (or `filepond`) field"                                                                                                                                                                                                                                                                                                                   
    — clearer hint about which keys are accepted.                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                           
  ## Test plan                                                                                                                                                                                                                                                                                                                                                                             
  - [x] POST `-F filepond=@…` → 200 (was 400)                                                                                                                                                                                                                                                                                                                                              
  - [x] POST `-F file=@…` → 200 (cURL convention still works)                                                                                                                                                                                                                                                                                                                              
  - [x] POST without file → 400 with the new message                                                                                                                                                                                                                                                                                                                                       
  - [ ] Browser: drag-drop in editor → 200 (replaces the 400)