### PR TITLE
feat(images): caption / alt text per image, end-to-end

### DIFF
--- a/boot/Editor/Api/UploadEndpoint.php
+++ b/boot/Editor/Api/UploadEndpoint.php
@@ -57,6 +57,7 @@ final class UploadEndpoint
     {
         match (strtoupper($method)) {
             'POST'   => $this->handlePost(),
+            'PATCH'  => $this->handlePatch(),
             'DELETE' => $this->handleDelete(),
             default  => $this->error(405, 'Method not allowed'),
         };
@@ -134,6 +135,40 @@ final class UploadEndpoint
         }
         $this->storage->write($thumbRel, $bytes);
         return $thumbRel;
+    }
+
+    /**
+     * Update the title (caption / alt text) of an existing file row.
+     * Body fields (form-urlencoded; PHP doesn't populate `$_POST` for
+     * PATCH so the body is parsed via {@see parseBody()}):
+     *
+     *   fileId      file id to update
+     *   title       new title; empty string clears the caption
+     *   tokenName, tokenValue
+     *
+     * Returns 200 `{"status":"ok","title":"..."}` on success,
+     * 404 when the file id is unknown, 400 on bad input.
+     */
+    private function handlePatch(): never
+    {
+        $body = self::parseBody();
+        $token  = (string) ($body['tokenName']  ?? $this->editor->input->getString('tokenName'));
+        $tokenV = (string) ($body['tokenValue'] ?? $this->editor->input->getString('tokenValue'));
+        $this->assertCsrf($token, $tokenV);
+
+        $fileId = isset($body['fileId']) ? (int) $body['fileId'] : 0;
+        if ($fileId < 1) {
+            $this->error(400, 'fileId is required');
+        }
+        $title = isset($body['title']) ? (string) $body['title'] : '';
+
+        $file = $this->files->find($fileId);
+        if ($file === null) {
+            $this->error(404, 'File not found');
+        }
+
+        $updated = $this->files->save($file->withTitle($title));
+        $this->json(200, ['status' => 'ok', 'title' => $updated->title]);
     }
 
     private function handleDelete(): never

--- a/boot/Editor/Pages/PagesModule.php
+++ b/boot/Editor/Pages/PagesModule.php
@@ -143,6 +143,24 @@ final class PagesModule
         $data['template']   = $template;
         $data['pagetype']   = $data['pagetype'] ?? '1';
 
+        // Legacy image titles: PagesModule::renderLegacyImageRow emits an
+        // input named `legacy_image_titles[<index>]` per migrated image
+        // entry. Splice each posted value back into the matching slot in
+        // data.images so the page-save persists caption edits without
+        // touching anything else on the entry.
+        $rawTitles = $this->editor->input->post('legacy_image_titles');
+        if (\is_array($rawTitles) && isset($data['images']) && \is_array($data['images'])) {
+            $images = $data['images'];
+            foreach ($rawTitles as $index => $title) {
+                $idx = (int) $index;
+                if (! isset($images[$idx]) || ! \is_array($images[$idx])) {
+                    continue;
+                }
+                $images[$idx]['title'] = (string) $title;
+            }
+            $data['images'] = $images;
+        }
+
         $now = time();
         $item = new Item(
             id:         $existing?->id(),
@@ -346,11 +364,11 @@ final class PagesModule
             $existingRows .= $this->renderUploadedFileRow($file);
         }
         $legacyRows = '';
-        foreach ($legacy as $img) {
+        foreach ($legacy as $index => $img) {
             if (! \is_array($img)) {
                 continue;
             }
-            $legacyRows .= $this->renderLegacyImageRow($img);
+            $legacyRows .= $this->renderLegacyImageRow($img, (int) $index);
         }
 
         $existingBlock = $existingRows !== ''
@@ -400,7 +418,7 @@ final class PagesModule
      *
      * @param array<string, mixed> $img
      */
-    private function renderLegacyImageRow(array $img): string
+    private function renderLegacyImageRow(array $img, int $index): string
     {
         $name  = (string) ($img['name']  ?? '');
         $title = (string) ($img['title'] ?? '');
@@ -419,18 +437,26 @@ final class PagesModule
         $assetUrl = $clean . $name;
 
         $i = static fn(string $s): string => htmlspecialchars($s, \ENT_QUOTES);
-        $titleHtml = $title !== '' ? ' <span class="muted">— ' . $i($title) . '</span>' : '';
 
-        return sprintf(
-            '<li class="image-list__item image-list__item--legacy">'
-                . '<a href="%s" target="_blank"><img src="%1$s" alt="%s" loading="lazy" width="120" height="120"></a>'
-                . ' <code>%s</code>%s'
-                . '</li>',
-            $i($assetUrl),
-            $i($name),
-            $i($name),
-            $titleHtml,
-        );
+        // Legacy titles persist back via the form's save-page action:
+        // the input's name encodes the array index so saveAction() can
+        // splice the new value into Item.data.images[$index].title.
+        $inputName = 'legacy_image_titles[' . $index . ']';
+
+        return '<li class="image-list__item image-list__item--legacy">'
+            . '<a href="' . $i($assetUrl) . '" target="_blank">'
+            . '<img src="' . $i($assetUrl) . '" alt="' . $i($name) . '" loading="lazy" width="120" height="120">'
+            . '</a>'
+            . ' <div class="image-list__meta">'
+                . '<code>' . $i($name) . '</code>'
+                . '<div class="image-list__title-edit">'
+                    . '<input type="text" name="' . $i($inputName) . '"'
+                        . ' value="' . $i($title) . '"'
+                        . ' placeholder="Caption / alt text">'
+                    . '<span class="muted">saves with the page</span>'
+                . '</div>'
+            . '</div>'
+            . '</li>';
     }
 
     private function renderUploadedFileRow(File $file): string
@@ -440,28 +466,39 @@ final class PagesModule
         // Public-URL convention from FileStorage::url() — the storage is
         // wired with /data/uploads-2.0 as its public base in the bootstrap.
         $base = '/data/uploads-2.0';
-        $assetUrl = \sprintf('%s/%s', $base, $file->path);
-        $thumbUrl = \sprintf('%s/%s/thumbnail/%s', $base, \dirname($file->path), $thumbName);
-        $token = $this->editor->csrf->token('pages');
+        $assetUrl = $base . '/' . $file->path;
+        $thumbUrl = $base . '/' . \dirname($file->path) . '/thumbnail/' . $thumbName;
+        $token  = $this->editor->csrf->token('pages');
+        $apiUrl = $this->editor->siteUrl . '/api/upload';
+        $id     = (int) $file->id;
 
-        return sprintf(
-            '<li class="image-list__item" data-file-id="%d">'
-                . '<a href="%s" target="_blank"><img src="%s" alt="%s" loading="lazy" width="120" height="120"></a>'
-                . ' <code>%s</code> <span class="muted">(%dx%d, %d bytes)</span>'
-                . ' <button type="button" class="image-list__remove" data-file-id="%1$d" data-csrf-name="pages" data-csrf-value="%s" data-delete-url="%s">'
-                . '<i class="gg-trash"></i> remove</button>'
-                . '</li>',
-            (int) $file->id,
-            $i($assetUrl),
-            $i($thumbUrl),
-            $i($file->name),
-            $i($file->name),
-            $file->width,
-            $file->height,
-            $file->size,
-            $i($token),
-            $i($this->editor->siteUrl . '/api/upload'),
-        );
+        return '<li class="image-list__item" data-file-id="' . $id . '">'
+            . '<a href="' . $i($assetUrl) . '" target="_blank">'
+            . '<img src="' . $i($thumbUrl) . '" alt="' . $i($file->name) . '" loading="lazy" width="120" height="120">'
+            . '</a>'
+            . ' <div class="image-list__meta">'
+                . '<code>' . $i($file->name) . '</code> '
+                . '<span class="muted">(' . $file->width . 'x' . $file->height . ', ' . $file->size . ' bytes)</span>'
+                . '<div class="image-list__title-edit">'
+                    . '<input type="text" class="image-list__title-input"'
+                        . ' placeholder="Caption / alt text"'
+                        . ' value="' . $i($file->title) . '"'
+                        . ' data-file-id="' . $id . '"'
+                        . ' data-csrf-name="pages"'
+                        . ' data-csrf-value="' . $i($token) . '"'
+                        . ' data-patch-url="' . $i($apiUrl) . '">'
+                    . '<button type="button" class="image-list__title-save" data-file-id="' . $id . '">save title</button>'
+                    . '<span class="image-list__title-status muted" data-file-id="' . $id . '"></span>'
+                . '</div>'
+            . '</div>'
+            . ' <button type="button" class="image-list__remove"'
+                . ' data-file-id="' . $id . '"'
+                . ' data-csrf-name="pages"'
+                . ' data-csrf-value="' . $i($token) . '"'
+                . ' data-delete-url="' . $i($apiUrl) . '">'
+                . '<i class="gg-trash"></i> remove'
+            . '</button>'
+            . '</li>';
     }
 
     private function fieldText(string $id, string $name, string $label, string $value, bool $required = false, string $infoText = ''): string

--- a/composer.lock
+++ b/composer.lock
@@ -12,7 +12,7 @@
             "dist": {
                 "type": "path",
                 "url": "../imanager",
-                "reference": "1c28b7e0bd68be277c5e87f8bad61d67a0c10c96"
+                "reference": "d88b1e9d29c6995aedbf0eb52af0640e22521f2b"
             },
             "require": {
                 "erusev/parsedown": "^1.7",

--- a/editor/theme/scripts/filepond-init.js
+++ b/editor/theme/scripts/filepond-init.js
@@ -131,5 +131,54 @@
         });
       });
     });
+
+    // Title-save buttons next to each modern file row: PATCHes the
+    // upload endpoint with the new caption. Status text appears
+    // briefly next to the input on success / failure.
+    document.querySelectorAll('.image-list__title-save').forEach(function (btn) {
+      btn.addEventListener('click', function (event) {
+        event.preventDefault();
+        var fileId = btn.dataset.fileId;
+        if (!fileId) { return; }
+
+        var item = btn.closest('.image-list__item');
+        if (!item) { return; }
+        var input = item.querySelector('.image-list__title-input');
+        var status = item.querySelector('.image-list__title-status');
+        if (!input) { return; }
+
+        var url      = input.dataset.patchUrl;
+        var csrfName = input.dataset.csrfName;
+        var csrfVal  = input.dataset.csrfValue;
+        if (!url) { return; }
+
+        var body = new URLSearchParams({
+          fileId: fileId,
+          title: input.value,
+          tokenName: csrfName || '',
+          tokenValue: csrfVal || ''
+        });
+        if (status) { status.textContent = 'saving…'; }
+
+        fetch(url, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          credentials: 'same-origin',
+          body: body.toString()
+        }).then(function (res) {
+          if (res.ok) {
+            if (status) {
+              status.textContent = 'saved';
+              setTimeout(function () { status.textContent = ''; }, 1500);
+            }
+          } else {
+            res.text().then(function (text) {
+              if (status) { status.textContent = 'failed'; }
+              console.error('Title save failed:', text);
+            });
+          }
+        });
+      });
+    });
   });
 })();

--- a/site/themes/basic/lib/Basic.php
+++ b/site/themes/basic/lib/Basic.php
@@ -410,7 +410,7 @@ class BasicTheme extends Site
                         // ImageUrlBuilder rewrites `data/uploads/` legacy
                         // prefixes only, so prepend the 2.0 root explicitly.
                         'path'     => 'data/uploads-2.0/' . \dirname($first->path) . '/',
-                        'title'    => '',
+                        'title'    => $first->title,
                         'position' => $first->position,
                     ];
                 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                               
  Brings 1.x image-title functional parity onto the 2.0 stack across all                                                                                                                                                                                                                                                                                                                   
  three layers, on top of the iManager `files.title` column.                                                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                                                                                                           
  **Editor — UploadEndpoint:**                                                                                                                                                                                                                                                                                                                                                             
  - New `PATCH` method: body `{fileId, title, tokenName, tokenValue}` →                                                                                                                                                                                                                                                                                                                    
    200 `{"status":"ok","title":"..."}` on success, 404 unknown id, 400                                                                                                                                                                                                                                                                                                                    
    missing fileId. Uses the same `parseBody()` helper as DELETE so it                                                                                                                                                                                                                                                                                                                     
    works regardless of whether the client posts the body as                                                                                                                                                                                                                                                                                                                               
    form-urlencoded PATCH or query string.                                                                                                                                                                                                                                                                                                                                                 
  - `handle()` routes PATCH alongside POST and DELETE.                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                           
  **Editor — PagesModule:**                                                                                                                                                                                                                                                                                                                                                                
  - `renderUploadedFileRow` emits an inline title input + "save title"                                                                                                                                                                                                                                                                                                                     
    button per file with `data-*` attributes the JS handler reads.                                                                                                                                                                                                                                                                                                                         
  - `renderLegacyImageRow` takes an index and emits an input named                                                                                                                                                                                                                                                                                                                         
    `legacy_image_titles[<index>]` so titles persist with the page save.                                                                                                                                                                                                                                                                                                                   
    Migrated 1.x entries stay in `Item.data.images` on purpose (Plan §9:                                                                                                                                                                                                                                                                                                                   
    no destructive migration).                                                                                                                                                                                                                                                                                                                                                             
  - `saveAction` merges any posted `legacy_image_titles[i]` back into                                                                                                                                                                                                                                                                                                                      
    `data.images[i].title` before re-saving the item.                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                           
  **Editor — filepond-init.js:**                                                                                                                                                                                                                                                                                                                                                           
  - New click handler on `.image-list__title-save`: PATCHes the upload                                                                                                                                                                                                                                                                                                                     
    endpoint, surfaces "saving…", "saved" (auto-clears after 1.5s), or                                                                                                                                                                                                                                                                                                                     
    "failed" on the row's status span.                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                           
  **Frontend — BasicTheme::headlineImage:**                                                                                                                                                                                                                                                                                                                                                
  - Modern attachments now propagate `$file->title` instead of the                                                                                                                                                                                                                                                                                                                         
    hardcoded `''`. Hero/figure templates already render `INFO` through                                                                                                                                                                                                                                                                                                                    
    `Sanitizer::markdown` so captions support inline markdown (links,                                                                                                                                                                                                                                                                                                                      
    emphasis), matching the 1.x path.                                                                                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                                           
  ## Test plan                                                                                                                                                                                                                                                                                                                                                                             
  - [x] POST upload → 200; fileId                                                                                                                                                                                                                                                                                                                                                          
  - [x] PATCH `title=Captured…` → 200 `{"status":"ok"}`; DB has the title                                                                                                                                                                                                                                                                                                                  
  - [x] Edit form refetch → title input prefilled with saved value;                                                                                                                                                                                                                                                                                                                        
         legacy input present (`legacy_image_titles[0]`)                                                                                                                                                                                                                                                                                                                                   
  - [x] POST save-page with `legacy_image_titles[0]=…` → 302;                                                                                                                                                                                                                                                                                                                              
         `data.images[0].title` updated in DB                                                                                                                                                                                                                                                                                                                                              
  - [x] Frontend (cache flushed) → caption rendered in hero                                                                                                                                                                                                                                                                                                                                
  - [ ] Browser: type in caption + save title button → status flashes                                                                                                                                                                                                                                                                                                                      
         "saved"; reload frontend → caption visible