### PR TITLE
Fix/page content double encoding

### DIFF
--- a/bin/fix-page-content-encoding.php
+++ b/bin/fix-page-content-encoding.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * One-shot migration — strip accumulated HTML-entity encoding from
+ * `data.content` of every Pages item.
+ *
+ * Background: PagesModule::saveAction() used to wrap the posted markdown
+ * in `htmlentities()` before storing, while the textarea round-trip
+ * re-escaped it on every render. Each save added one extra encoding
+ * layer (`>` → `&gt;` → `&amp;gt;` → `&amp;amp;gt;` …). The save-time
+ * encoding is gone in 2.0; this script normalises rows that were edited
+ * one or more times under the buggy code.
+ *
+ * Algorithm: run `html_entity_decode()` repeatedly until the value
+ * stops changing (capped at 10 iterations). That undoes any number of
+ * stacked `htmlentities()` passes without touching content that was
+ * already raw.
+ *
+ * Usage:
+ *   php bin/fix-page-content-encoding.php
+ *   php bin/fix-page-content-encoding.php --db=/path/to/other.db
+ *   php bin/fix-page-content-encoding.php --dry-run
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Imanager\Domain\Item;
+use Imanager\Storage\Sqlite\ConnectionFactory;
+use Imanager\Storage\Sqlite\SqliteStorage;
+
+$dbPath = __DIR__ . '/../data/imanager.db';
+$dryRun = false;
+foreach ($argv as $arg) {
+    if (str_starts_with($arg, '--db=')) {
+        $dbPath = substr($arg, 5);
+    } elseif ($arg === '--dry-run') {
+        $dryRun = true;
+    }
+}
+if (! is_file($dbPath)) {
+    fwrite(STDERR, "Database not found: {$dbPath}\n");
+    exit(1);
+}
+
+$pdo = (new ConnectionFactory($dbPath))->create();
+$storage = new SqliteStorage($pdo);
+
+$pages = $storage->categories()->findBySlug('pages');
+if ($pages === null || $pages->id === null) {
+    fwrite(STDERR, "No 'pages' category in {$dbPath}\n");
+    exit(1);
+}
+
+$total    = $storage->items()->countByCategory($pages->id);
+$batch    = 100;
+$offset   = 0;
+$touched  = 0;
+$skipped  = 0;
+$maxRound = 10;
+
+echo "Scanning {$total} pages in {$dbPath}" . ($dryRun ? ' (dry-run)' : '') . "\n";
+echo str_repeat('-', 70) . "\n";
+
+while ($offset < $total) {
+    $items = $storage->items()->findByCategory($pages->id, $offset, $batch);
+    foreach ($items as $item) {
+        $original = $item->data->get('content');
+        if (! is_string($original) || $original === '') {
+            $skipped++;
+            continue;
+        }
+
+        $decoded = $original;
+        $rounds  = 0;
+        while ($rounds < $maxRound) {
+            $next = html_entity_decode($decoded, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+            if ($next === $decoded) {
+                break;
+            }
+            $decoded = $next;
+            $rounds++;
+        }
+
+        if ($decoded === $original) {
+            $skipped++;
+            continue;
+        }
+
+        printf("  #%-5d %-40s  -%d layer(s)\n", $item->id ?? 0, mb_strimwidth((string) $item->name, 0, 40, '…'), $rounds);
+
+        if (! $dryRun) {
+            $newData = $item->data->with('content', $decoded);
+            $storage->items()->save(new Item(
+                id:         $item->id,
+                categoryId: $item->categoryId,
+                name:       $item->name,
+                label:      $item->label,
+                position:   $item->position,
+                active:     $item->active,
+                data:       $newData,
+                created:    $item->created,
+                updated:    time(),
+            ));
+        }
+        $touched++;
+    }
+    $offset += $batch;
+}
+
+echo str_repeat('-', 70) . "\n";
+echo $dryRun
+    ? "Dry-run: {$touched} would be rewritten, {$skipped} unchanged.\n"
+    : "Done: {$touched} rewritten, {$skipped} unchanged.\n";

--- a/boot/Editor/Pages/PagesModule.php
+++ b/boot/Editor/Pages/PagesModule.php
@@ -123,12 +123,11 @@ final class PagesModule
             ? $this->editor->sanitizer->text(str_replace('"', '', $menuTitleRaw))
             : $name;
 
-        $contentRaw = $this->editor->input->postString('content');
-        if ($contentRaw === '') {
+        $content = $this->editor->input->postString('content');
+        if ($content === '') {
             $this->editor->addMsg('error', $this->t('error_page_content') ?: 'Page content is required.');
             return;
         }
-        $content = htmlentities($contentRaw);
 
         $template = $this->editor->sanitizer->templateName($this->editor->input->postString('template'));
         $active   = $this->editor->input->postString('published') !== '';
@@ -233,7 +232,7 @@ final class PagesModule
     private function markdownPreviewAction(): void
     {
         $rendered = $this->editor->sanitizer->markdown(
-            htmlspecialchars_decode($this->editor->input->postString('content')),
+            $this->editor->input->postString('content'),
         );
         $this->jsonResponse(['status' => 1, 'text' => $rendered]);
     }

--- a/boot/Frontend/Site.php
+++ b/boot/Frontend/Site.php
@@ -317,9 +317,10 @@ class Site
             return '';
         }
         // Page content is stored as raw Markdown. Parsedown safe-mode
-        // escapes any embedded HTML; when allowHtmlOutput is true the
-        // input may also contain author-supplied HTML and Parsedown
-        // passes it through.
+        // escapes embedded HTML and rewrites non-whitelisted URL schemes
+        // (no `javascript:` etc.). A future plugin that introduces an
+        // alternative content format should dispatch on a per-page
+        // marker rather than reinstating a global flag here.
         return $this->sanitizer->markdown($this->page->content);
     }
 

--- a/boot/Frontend/Site.php
+++ b/boot/Frontend/Site.php
@@ -316,16 +316,11 @@ class Site
         if ($this->page === null) {
             return '';
         }
-        $content = $this->page->content;
-        $allowHtml = (bool) ($this->config['allowHtmlOutput'] ?? false);
-        // Markdown rendering through iManager's Sanitizer (Parsedown +
-        // optional HTMLPurifier). When allowHtmlOutput is true the input
-        // may already contain raw HTML; either way Parsedown runs and
-        // safe-mode strips dangerous tags on entry when html is disabled.
-        $rendered = $this->sanitizer->markdown(
-            $allowHtml ? $content : htmlspecialchars_decode($content),
-        );
-        return $rendered;
+        // Page content is stored as raw Markdown. Parsedown safe-mode
+        // escapes any embedded HTML; when allowHtmlOutput is true the
+        // input may also contain author-supplied HTML and Parsedown
+        // passes it through.
+        return $this->sanitizer->markdown($this->page->content);
     }
 
     protected function renderNavigation(): string

--- a/data/settings/scriptor-config.php
+++ b/data/settings/scriptor-config.php
@@ -120,13 +120,6 @@ $config = [
 	'maxConfigBackupFiles' => 5,
 
 	/**
-	 * Enable HTML tags in page content output.
-	 * 
-	 * @var bool
-	 */
-	'allowHtmlOutput' => false,
-
-	/**
 	 * Array with reserved slugs.
 	 * 
 	 * @var array 

--- a/editor/theme/scripts/editor.js
+++ b/editor/theme/scripts/editor.js
@@ -1,8 +1,9 @@
 (function() {
 	// https://highlightjs.org/
 	var md = new Remarkable('full', {
-		// Enable HTML tags in source
-		html: (typeof editConf !== 'undefined') ? editConf.allowHtmlOutput : false,
+		// Page content is Markdown. Parsedown safe-mode is the authority on
+		// the server side; the preview matches by disabling raw-HTML passthrough.
+		html: false,
 		xhtmlOut:     false,        // Use '/' to close single tags (<br />)
 		breaks:       false,        // Convert '\n' in paragraphs into <br>
 		langPrefix:   'language-',  // CSS language prefix for fenced blocks

--- a/site/themes/basic/lib/Basic.php
+++ b/site/themes/basic/lib/Basic.php
@@ -294,7 +294,7 @@ class BasicTheme extends Site
     private function renderArticleSummary(Page $article): string
     {
         $limit = (int) ($this->themeConfig['summary_character_len'] ?? 400);
-        $text  = htmlspecialchars_decode($article->content);
+        $text  = $article->content;
         if ($limit > 0 && mb_strlen($text) > $limit) {
             $text = mb_substr($text, 0, $limit) . ' …';
         }


### PR DESCRIPTION
## Page content double-encoding (d7aaf6a)
  PagesModule.saveAction() wrapped the posted markdown in `htmlentities()`
  before storing, while the textarea round-trip re-escaped on every render.
  Each save added one extra layer (`>` → `&gt;` → `&amp;gt;` → …), so
  content edited multiple times accumulated visible HTML entities in
  both blockquotes and code blocks.

  - PagesModule: store posted content raw; drop the orphan
    `htmlspecialchars_decode()` from the markdown preview action.
  - Site::renderContent(): pass `$page->content` straight to Parsedown.
  - BasicTheme::renderArticleSummary(): drop the orphan decode.
  - bin/fix-page-content-encoding.php: one-shot migration. Walks all
    Pages items and runs `html_entity_decode()` on `data.content` until
    stable (cap 10 rounds). Supports `--dry-run` and `--db=`.

  ## Drop dead allowHtmlOutput flag (bd08e0c)
  `allowHtmlOutput` had no live consumer left after the renderContent
  cleanup, and the editor.js reference read it off a `editConf` JS bag
  that no PHP ever populated. A global "trust author HTML" flag is the
  wrong granularity for the planned WYSIWYG plugin (which will need
  per-page format dispatch), so dropping it now keeps the security
  story crisp without closing any door for later.

  - scriptor-config.php: remove the key + docblock.
  - editor.js: hard-code `html: false` for the Remarkable preview.
  - Site::renderContent(): refresh the comment to document the safe-mode
    contract and the per-page dispatch hint.

  ## Smoke
  - Migration on live db: 3 rewritten (-4 / -1 / -1 layers), 6 unchanged.
  - Frontend: blockquote renders as `<blockquote>`, code block has
    single-layer escaping (`-&gt;` → browser shows `->`), no
    `&amp;amp;` in source after merge.
  - Storage round-trip: 3× save+reload returns byte-identical content.
  - XSS regression check: 7 attack vectors (`<script>`, inline event
    handlers, `javascript:`/`data:` URIs, `<svg onload=>`, `<iframe>`,
    `<input autofocus onfocus=>`) all neutralised by Parsedown safe-mode.