### PR TITLE
fix(pages): server-side cycle guard for parent save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,19 @@ dispatch, PSR-16 caching). The legacy 1.x flat-file storage is gone.
   `Sanitizer`, `ImageUrlBuilder` — public-site renderer that bundled
   themes consume through the standard `$site` surface.
 
+### Fixed
+
+- **Pages tree: indirect-cycle guard on parent save.**
+  `PageRepository::wouldCreateCycle()` walks the proposed parent's
+  existing chain upwards; if it reaches the page being edited,
+  `PagesModule::saveAction()` refuses the save with a localised
+  error (`error_page_parent_cycle`, en + de). The direct
+  self-parent case was already collapsed to root, but indirect
+  cycles (a → b → c → a) could be saved silently. The frontend's
+  `Site::buildPageUrl()` already tolerates cyclic data via a
+  visited-set guard, so the editor now matches the frontend's
+  defensive shape.
+
 ### Removed
 
 - `Scriptor/imanager/` — the entire embedded 1.x library (~850 KB).

--- a/boot/Editor/Pages/PagesModule.php
+++ b/boot/Editor/Pages/PagesModule.php
@@ -119,6 +119,23 @@ final class PagesModule
             $parentId = 0;
         }
 
+        // Cycle guard: reject the save if the proposed parent's chain
+        // walks back through the page being edited (a → b → … → a). The
+        // direct self-parent case above already collapses to root, so this
+        // catches *indirect* cycles. Only relevant when editing an
+        // existing page — a brand-new page has no dependants yet.
+        if ($existing !== null
+            && $parentId !== 0
+            && $this->pages->wouldCreateCycle($existing->id() ?? 0, $parentId)
+        ) {
+            $this->saveError(
+                $isXhr,
+                $this->t('error_page_parent_cycle')
+                    ?: 'Cannot set this parent — it would create a cycle in the page tree.',
+            );
+            return;
+        }
+
         if ($this->pages->slugTaken($slug, $parentId, $existing?->id())) {
             $this->saveError($isXhr, $this->t('error_page_title_exists') ?: 'A page with that slug already exists under this parent.');
             return;

--- a/boot/Frontend/PageRepository.php
+++ b/boot/Frontend/PageRepository.php
@@ -229,6 +229,64 @@ final readonly class PageRepository
         return false;
     }
 
+    /**
+     * Would setting `$pageId`'s parent to `$candidateParentId` create a cycle?
+     *
+     * Walks the candidate parent's existing chain upwards; if it eventually
+     * passes through `$pageId`, the proposed save would close a loop. We
+     * deliberately don't pre-simulate the save into the storage layer — we
+     * just chase the candidate's *current* chain, because the only new edge
+     * created by the proposed save is `pageId → candidateParentId`, and the
+     * cycle test "does the candidate's chain reach pageId" already covers
+     * every loop that edge can produce.
+     *
+     * Edge cases:
+     *   - `$candidateParentId === 0` — no parent change to a root can ever
+     *     create a cycle.
+     *   - `$pageId === 0` — a brand-new page that isn't persisted yet has no
+     *     dependants, so no cycle is possible.
+     *   - `$candidateParentId === $pageId` — direct self-parent. Always a
+     *     cycle. (Caught defensively here; PagesModule also collapses this
+     *     case to 0 before reaching us, but a stale callsite shouldn't be
+     *     able to bypass the check.)
+     *   - The candidate's chain already contains a cycle that doesn't pass
+     *     through `$pageId` — pre-existing data corruption. We bail
+     *     truthfully (return false) rather than blame the save for an issue
+     *     that was already there.
+     *   - Broken parent pointer (parent id doesn't resolve to a page) — we
+     *     stop walking and return false; you don't reject a save because of
+     *     someone else's dangling reference.
+     */
+    public function wouldCreateCycle(int $pageId, int $candidateParentId): bool
+    {
+        if ($candidateParentId === 0 || $pageId === 0) {
+            return false;
+        }
+        if ($candidateParentId === $pageId) {
+            return true;
+        }
+
+        /** @var array<int, true> $visited */
+        $visited = [];
+        $current = $candidateParentId;
+        while ($current !== 0) {
+            if ($current === $pageId) {
+                return true;
+            }
+            if (isset($visited[$current])) {
+                return false;
+            }
+            $visited[$current] = true;
+
+            $parent = $this->find($current);
+            if ($parent === null) {
+                return false;
+            }
+            $current = $parent->parent;
+        }
+        return false;
+    }
+
     public function nextPosition(): int
     {
         $items = $this->items->findByCategory($this->categoryId);

--- a/editor/lang/de_DE.php
+++ b/editor/lang/de_DE.php
@@ -83,6 +83,7 @@ $i18n = [
 	'error_slug_reserved' => 'Dieser Slug ist reserviert und kann nicht verwendet werden.',
 	'error_page_title_exists' => 'Seite konnte nicht gespeichert werden, da bereits eine Seite mit demselben Namen existiert.',
 	'error_page_content' => 'Feld Inhalt darf nicht leer sein.',
+	'error_page_parent_cycle' => 'Dieses Übergeordnete-Element ist nicht zulässig — es würde einen Zyklus im Seitenbaum erzeugen.',
 	'successful_saved_page' => 'Die Seite wurde erfolgreich gespeichert.',
 	'parent_select_option' => 'Auswählen',
 	'error_deleting_first_page' => 'Fehler beim Löschen von primären Seite. Die Seite mit der ID 1, kann nicht gelöscht werden.',

--- a/editor/lang/en_US.php
+++ b/editor/lang/en_US.php
@@ -83,6 +83,7 @@ $i18n = [
 	'error_slug_reserved' => 'This slug is reserved and cannot be used.',
 	'error_page_title_exists' => 'Page could not be saved, a page with the specified name already exists.',
 	'error_page_content' => 'The Content field is mandatory.',
+	'error_page_parent_cycle' => 'Cannot set this parent — it would create a cycle in the page tree.',
 	'successful_saved_page' => 'The page was saved successfully.',
 	'parent_select_option' => 'Select option',
 	'error_deleting_first_page' => 'Error when deleting primary page. The page with ID 1, cannot be deleted.',


### PR DESCRIPTION
The Pages editor already rejected direct self-parent on save (a → a was collapsed to root). Indirect cycles (a → b → a, or a → b → c → a) slipped through silently, leaving the storage in a state the frontend's URL builder had to defend against at render time (the existing `Site::buildPageUrl()` carries a visited-set guard for exactly this reason).

This commit closes the loophole at save-time. New
`PageRepository::wouldCreateCycle(int $pageId, int $candidateParentId)`:

  - Walks the candidate parent's existing chain upwards via repeated `find()` calls; if `$pageId` appears in that chain, the proposed edge would close a loop. Returns true.
  - Returns false on the no-op cases: candidate is root, the page being saved isn't persisted yet, candidate equals the page (the last one is caught defensively — `PagesModule` already collapses direct self-parent to root).
  - Tolerates pre-existing data corruption: if the candidate's chain is *itself* cyclic without involving `$pageId`, the proposed save isn't responsible for that, so we don't refuse it. The visited set bails the walk on revisits.
  - Tolerates broken parent pointers (dangling id): the walk stops when `find()` returns null; we don't reject the save on someone else's missing reference.

`PagesModule::saveAction()` calls the guard right after the existing direct-self-parent normalisation, only when both an existing page and a non-root candidate parent are in play. The error surfaces through the same `saveError` channel the rest of the save flow uses — a new localised key `error_page_parent_cycle` (en + de) carries the user-facing message.

No test suite to add to (Scriptor doesn't ship one); syntax-clean under PHP 8.4. Manual verification path: in the editor, take pages A and B, set A.parent = B, save; then edit B and try to set B.parent = A. The save now refuses with the cycle error instead of silently committing.