### PR TITLE
chore(htaccess): refresh Apache fallback rules for 2.0 layout

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,35 +5,34 @@
 
     Options -Indexes
     Options +SymLinksIfOwnerMatch
-    # Options +SymLinksifOwnerMatch
-
-    # RewriteBase /
 
     # Redirecting HTTP to HTTPS
     # RewriteCond %{SERVER_PORT} 80
     # RewriteRule ^(.*)$ https://your-website.com/$1 [R,L]
-    
-    # Allow harmless files
-    RewriteCond %{REQUEST_URI} !\.(?:css|js|map|jpe?g|gif|png|svg|webp)$
-    # Allow file upload handler
-    RewriteCond %{REQUEST_URI} !(^|/)imanager/upload/server/php($|/.*$)$
 
-    # Block some directories and files
-    RewriteCond %{REQUEST_URI} (^|/)(boot|imanager)(.php$) [NC,OR]
-    # Block access to certain native Scriptor files.
-    RewriteCond %{REQUEST_URI} (^|/)(.htaccess|data|imanager|modules|core|lang|_.*)($|/.*$) [NC,OR]
-    # Forbid access to all directories and files that start with a dot
+    # ----------------------------------------------------------------
+    # Deny chain — fires only when ALL conditions match.
+    # The first condition lets harmless static assets pass through;
+    # the rest enumerate paths that must never be served directly.
+    # ----------------------------------------------------------------
+
+    RewriteCond %{REQUEST_URI} !\.(?:css|js|map|jpe?g|gif|png|svg|webp|woff2?|ttf|eot)$
+
+    # Block direct execution of the bootstrap stub.
+    RewriteCond %{REQUEST_URI} (^|/)boot\.php$ [NC,OR]
+    # Block direct access to source code, configuration and CLI dirs.
+    RewriteCond %{REQUEST_URI} (^|/)(data|boot|vendor|bin|lang)($|/.*$) [NC,OR]
+    # Forbid every dot-file (.htaccess, .git, .env, .DS_Store, ...).
     RewriteCond %{REQUEST_URI} (^|/)\.[^/]*($|/.*$)
 
     RewriteRule ^ - [F,L]
 
-    # Block access to .zip, .pdf, and .tar files under "/data/uploads/"
-    #RewriteCond %{REQUEST_URI} /data/uploads/.*\.(zip|pdf|tar)$ [NC]
-    #RewriteRule ^ - [F,L]
-
-    RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteRule ^editor/(.*)$ editor/index.php?id=$1 [L,QSA]
+    # ----------------------------------------------------------------
+    # Front controller — route everything that isn't a real file or
+    # directory to index.php. Scriptor's index.php handles the
+    # admin-path delegation in PHP, so changing `admin_path` in
+    # data/settings/scriptor-config.php needs no .htaccess update.
+    # ----------------------------------------------------------------
 
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,20 @@ dispatch, PSR-16 caching). The legacy 1.x flat-file storage is gone.
   side-step the missing path-repo). The Dockerfile now runs a
   plain `composer install --no-dev`. `docker/composer-rewrite.php`
   is removed.
+- **`.htaccess` refreshed for the 2.0 layout.** The Apache fallback
+  rules now match what actually lives in the tree: directory deny
+  list switched from the gone `imanager`/`modules`/`core` to the
+  current `boot`/`vendor`/`bin` (real source dirs); legacy
+  `imanager/upload/server/php` exception removed; the literal
+  `editor/`-rewrite is gone — every request lands on `index.php`
+  which delegates `/<admin_path>/*` in PHP, so changing
+  `admin_path` no longer requires editing `.htaccess`. The static
+  asset whitelist gained `woff/woff2/ttf/eot` for theme fonts.
+  Caddy and nginx ignore `.htaccess` entirely; this is purely an
+  Apache-fallback hygiene pass.
+- **`scriptor-config.php` admin_path comment** no longer claims
+  the user must update `.htaccess` after changing `admin_path`.
+  The 2.0 PHP-level delegation in `index.php` makes that obsolete.
 
 ### Removed
 

--- a/data/settings/scriptor-config.php
+++ b/data/settings/scriptor-config.php
@@ -49,9 +49,11 @@ $config = [
 	/**
 	 * Relative path to the admin folder.
 	 *
-	 * Please note that if you change the folder name, you also need to update the paths
-	 * in the .htaccess file in the root directory accordingly.
-	 * 
+	 * The folder must exist on disk and contain `index.php` (the admin entry).
+	 * Routing to this path is handled in PHP (`index.php` delegates
+	 * `/<admin_path>/*` to `<admin_path>/index.php`), so no web-server
+	 * rewrite rules need to be touched when this value changes.
+	 *
 	 * @var string
 	 */
 	'admin_path' => 'editor/',


### PR DESCRIPTION
The .htaccess only matters for Apache deployments — Caddy (live install) and nginx (Docker demo) ignore it. But its deny list still referenced gone 1.x directories (`imanager/`, `modules/`, `core/`) and missed the new PSR-4 source roots (`boot/`, `vendor/`), so on a hypothetical Apache deployer it was simultaneously dead code AND a small defense-in-depth hole. Refreshed:

- directory deny list: drop gone `imanager|modules|core`, add `boot|vendor|bin` (real PHP source);
- file deny: drop `imanager.php` (gone), keep `boot\.php`;
- drop the legacy `imanager/upload/server/php` exception (handler retired in 2.0);
- drop the literal `^editor/(.*)` rewrite — the catch-all routes every non-file/dir request to `index.php`, which delegates `/<admin_path>/*` to the editor entry in PHP. Changing `admin_path` in the config now requires no .htaccess edit;
- extend the static-asset whitelist with `woff|woff2|ttf|eot` so theme fonts pass the deny chain;
- fix unescaped `.` in the regexes.

Also drop the matching stale comment in `data/settings/scriptor-config.php` (`admin_path`) that told users they had to update `.htaccess` when changing the admin folder name.

Plus: remove the empty `imanager/` leftover directory at the repo root (Phase 14f deleted its contents but the dir lingered, only holding a .DS_Store).