### PR TITLE
docs(refactor): note accepted dotfile-leak on ServBay Caddy

### DIFF
--- a/docs/refactor-public-webroot.md
+++ b/docs/refactor-public-webroot.md
@@ -698,6 +698,28 @@ files landing under `public/uploads/` in the new layout vs.
    UI Web-Root flip is reversible in seconds, full smoke + Apache +
    nginx + php-S coverage runs pre-merge anyway.
 
+### Known limitation — accepted
+
+- **ServBay's `php-rewrite-default` Caddy snippet has no dotfile
+  block.** After the live deploy, `https://scriptor.cms/.htaccess`
+  serves the file's contents byte-for-byte — Caddy's `file_server`
+  has no special handling for dotfiles. The leak is informational
+  only (the file just enumerates the Apache fallback rules; all
+  truly-sensitive paths live outside `public/` and are physically
+  unreachable). `.env` and `/.git/...` are also outside `public/`,
+  so they're not affected. Decision: leave it. The Hetzner demo
+  ships its own `docker/nginx.conf` which already blocks dotfiles
+  via `location ~ /\.(?!well-known) { … }`. If ServBay-local hygiene
+  becomes important later, add to the site's Caddy stanza:
+
+  ```caddy
+  @dotfiles {
+      path_regexp dotfiles ^/(\.|.*/\.)[^/]+
+      not path /.well-known/*
+  }
+  respond @dotfiles 404
+  ```
+
 ---
 
 ## 10. Shared-hosting recipe (documentation snippet)


### PR DESCRIPTION
After the live deploy on https://scriptor.cms, the `/.htaccess` file is served byte-for-byte by Caddy because ServBay's bundled `php-rewrite-default` snippet has no dotfile-block rule. Decision: accepted — the file only enumerates Apache fallback rules, and the real sensitive paths (boot/, vendor/, data/, .git/) all live OUTSIDE public/ and stay physically unreachable.

Documented for future-self plus the Caddy snippet to enable the block if ServBay-local hygiene matters later. The Hetzner demo already ships dotfile-block via docker/nginx.conf.