### PR TITLE
fix(url): trust X-Forwarded-Proto for site URL scheme

### DIFF
--- a/boot/Editor/Editor.php
+++ b/boot/Editor/Editor.php
@@ -247,7 +247,13 @@ class Editor
 
     private static function detectSiteUrl(): string
     {
-        $scheme = (! empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+        // Prefer X-Forwarded-Proto when present — TLS-terminating reverse
+        // proxies (nginx-proxy, traefik, …) reach PHP over plain HTTP
+        // and signal the original scheme via this header. First value
+        // wins for chained proxies ("https,http").
+        $proto = $_SERVER['HTTP_X_FORWARDED_PROTO']
+            ?? ((! empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http');
+        $scheme = strtolower(trim(explode(',', $proto)[0])) === 'https' ? 'https' : 'http';
         $host   = $_SERVER['HTTP_HOST'] ?? 'localhost';
         return $scheme . '://' . $host;
     }

--- a/boot/Frontend/Site.php
+++ b/boot/Frontend/Site.php
@@ -367,7 +367,13 @@ class Site
 
     private static function detectSiteUrl(): string
     {
-        $scheme = (! empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+        // Prefer X-Forwarded-Proto when present — TLS-terminating reverse
+        // proxies (nginx-proxy, traefik, …) reach PHP over plain HTTP
+        // and signal the original scheme via this header. First value
+        // wins for chained proxies ("https,http").
+        $proto = $_SERVER['HTTP_X_FORWARDED_PROTO']
+            ?? ((! empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http');
+        $scheme = strtolower(trim(explode(',', $proto)[0])) === 'https' ? 'https' : 'http';
         $host   = $_SERVER['HTTP_HOST'] ?? 'localhost';
         return $scheme . '://' . $host;
     }


### PR DESCRIPTION
Both Site::detectSiteUrl and Editor::detectSiteUrl looked only at $_SERVER['HTTPS'], which is unset when PHP sits behind a TLS-terminating reverse proxy (nginx-proxy, traefik, …). Result: every absolute URL the templates emit (asset hrefs, form actions, navigation links) was http:// even though the page itself was served over https — every modern browser blocks the assets as Mixed Content.

Now both check HTTP_X_FORWARDED_PROTO first, falling back to the $_SERVER['HTTPS'] heuristic. First value wins for chained proxies ('https,http') so a downstream http hop can't downgrade the scheme.

Verified by hitting https://demos.scriptor-cms.dev (nginx-proxy + acme-companion on Hetzner) — no more Mixed Content warnings.