### PR TITLE
refactor(docker): split scriptor-app into data + uploads volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,20 @@
 # Two services:
 #   scriptor — php:8.3-fpm-alpine + iManager 2.0; runs the entrypoint
 #              that bootstraps a fresh demo database on first start.
-#   web      — nginx:alpine fronting it on http://localhost:8080.
+#   web      — nginx:alpine + the public/ webroot baked in; fronts
+#              scriptor on http://localhost:8080 and forwards .php to
+#              scriptor's fastcgi.
 #
-# Filesystem sharing: both services mount the same named volume
-# `scriptor-app` at `/var/www/scriptor`. On first `docker compose up`,
-# Docker initialises the empty volume from the scriptor image's
-# baked-in filesystem (source + vendor/). Subsequent starts reuse the
-# volume; `docker compose down -v` resets the demo to factory-fresh.
+# Volume strategy: code lives in the IMAGES (rebuilt on every
+# `docker compose up -d --build`); only mutable state is in named
+# volumes:
+#   scriptor-data    → /var/www/scriptor/data         (SQLite, cache,
+#                                                      logs, settings)
+#   scriptor-uploads → /var/www/scriptor/public/uploads (FileStorage)
+#
+# This means `git pull && docker compose up -d --build` propagates
+# code changes; the DB and uploads survive container recreation.
+# `docker compose down -v` still resets the demo to factory-fresh.
 
 services:
   scriptor:
@@ -20,7 +27,8 @@ services:
     container_name: scriptor-demo
     restart: unless-stopped
     volumes:
-      - scriptor-app:/var/www/scriptor
+      - scriptor-data:/var/www/scriptor/data
+      - scriptor-uploads:/var/www/scriptor/public/uploads
     healthcheck:
       test: ["CMD-SHELL", "php -r \"exit(file_exists('/var/www/scriptor/data/imanager.db') ? 0 : 1);\""]
       interval: 5s
@@ -29,7 +37,10 @@ services:
       start_period: 30s
 
   web:
-    image: nginx:alpine
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.web
+    image: bigins/scriptor-demo-web:latest
     container_name: scriptor-demo-web
     restart: unless-stopped
     depends_on:
@@ -41,7 +52,8 @@ services:
       - "${SCRIPTOR_DEMO_PORT:-8080}:80"
     volumes:
       - ./docker/nginx.conf:/etc/nginx/nginx.conf:ro
-      - scriptor-app:/var/www/scriptor:ro
+      - scriptor-uploads:/var/www/scriptor/public/uploads:ro
 
 volumes:
-  scriptor-app:
+  scriptor-data:
+  scriptor-uploads:

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -1,0 +1,16 @@
+# Scriptor 2.0 — demo web image.
+#
+# Tiny nginx:alpine with the public/ webroot baked in. Pairs with the
+# php-fpm container (docker/Dockerfile) — both images carry an identical
+# copy of public/ so SCRIPT_FILENAME paths resolve in both places when
+# nginx forwards a .php request via fastcgi.
+#
+# At runtime, public/uploads/ is overlaid by the scriptor-uploads named
+# volume so user uploads persist across rebuilds.
+
+FROM nginx:alpine
+
+# Static webroot — everything in public/ except uploads/, which is
+# volume-mounted at runtime. .dockerignore handles the rest of the
+# noise (data/, vendor/, .git/, etc.).
+COPY public/ /var/www/scriptor/public/


### PR DESCRIPTION
The previous setup mounted a single named volume `scriptor-app` over the entire `/var/www/scriptor` in both containers. Docker only copy-initialises a named volume from the image once, so subsequent `docker compose up -d --build` updates rebuilt the image but the running container kept reading the OLD code from the volume — making code updates require `docker compose down -v`, which also wipes the demo DB and uploads.

This split puts code in the IMAGES (rebuilt fresh on every build) and only mutable state in named volumes:

  scriptor-data    → /var/www/scriptor/data
  scriptor-uploads → /var/www/scriptor/public/uploads

The web service now builds from a tiny new docker/Dockerfile.web that bakes public/ into nginx:alpine — both containers have an identical public/ tree, so SCRIPT_FILENAME paths resolve in both when nginx forwards .php to fastcgi. The web container also mounts scriptor-uploads:ro so it can serve user uploads.

Verified locally on macOS Docker 28.1:
  - up -d --build → both containers healthy, smoke matrix passes
  - down (no -v) + up → DB bytes + mtime preserved exactly
  - simulate code change + up -d --build → new code in container, DB still at original bytes + mtime
  - down -v → both volumes removed, fresh seed on next up

Migration on existing deployments: a one-time `docker compose down -v` is needed (the old `scriptor-app` volume is no longer referenced and can be `docker volume rm`'d). After that, code updates flow through cleanly without ever touching state again.