### PR TITLE
fix(demo): recreate FTS5 index after seed restore

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -38,6 +38,12 @@ if [ ! -f "${DB_PATH}" ]; then
         echo "[entrypoint] extracting ${SEED_UPLOADS} into public/."
         su -s /bin/sh -c "tar xzf ${SEED_UPLOADS} -C public/" www-data
     fi
+    # `imanager dump` (sqlite3 .dump) silently skips FTS5 virtual tables, so
+    # the seed leaves items_fts missing even though schema_version says the
+    # FTS migration ran. Re-apply the migration SQL and repopulate the index.
+    echo "[entrypoint] recreating FTS5 index (dump skips virtual tables)."
+    su -s /bin/sh -c "sqlite3 ${DB_PATH} < vendor/bigins/imanager/config/schema/0002_fts.sql" www-data
+    su -s /bin/sh -c "vendor/bin/imanager fts:rebuild --db=${DB_PATH}" www-data
     echo "[entrypoint] seed restore complete."
 fi
 


### PR DESCRIPTION
`vendor/bin/imanager dump` (which is `sqlite3 .dump` under the hood) silently skips FTS5 virtual tables. The seed restore therefore left items_fts (and its shadow tables) missing even though schema_version recorded the FTS migration as applied — `schema:migrate` saw no pending work, the table never came back, and any item write (saving a page, changing the admin password) blew up with:

    SQLSTATE[HY000]: General error: 1 no such table: items_fts

The entrypoint now re-applies the FTS migration's CREATE VIRTUAL TABLE after loading the seed and runs `imanager fts:rebuild` to populate the index from the items the seed restored.

Verified locally: fresh `up -d --build` shows
`[OK] FTS index rebuilt; 9 row(s) indexed.` and item UPDATEs succeed.

Followup worth filing upstream: `imanager dump` should either include virtual tables or warn loudly that the dump is incomplete.