### PR TITLE
chore(deps): bump bigins/imanager 2.0.0 -> 2.0.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,9 @@
 * text=auto
 *.tpl linguist-language=HTML
 *.php linguist-language=PHP
+
+# Seed dumps carry verbatim user content (e.g. CRLF inside markdown
+# bodies pasted into the editor). Disable line-ending normalisation so
+# the round-trip via `imanager dump` stays byte-identical to source.
+docker/seed-demo.sql -text
+docker/seed-demo-uploads.tar.gz binary

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "bigins/imanager",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bigin/imanager.git",
-                "reference": "231ca442cb00014d8c1f86d32e91e54a55f2ce08"
+                "reference": "397b9616f361a5d44be5cc0c88c00f66d3deec0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bigin/imanager/zipball/231ca442cb00014d8c1f86d32e91e54a55f2ce08",
-                "reference": "231ca442cb00014d8c1f86d32e91e54a55f2ce08",
+                "url": "https://api.github.com/repos/bigin/imanager/zipball/397b9616f361a5d44be5cc0c88c00f66d3deec0c",
+                "reference": "397b9616f361a5d44be5cc0c88c00f66d3deec0c",
                 "shasum": ""
             },
             "require": {
@@ -80,9 +80,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bigin/imanager/issues",
-                "source": "https://github.com/bigin/imanager/tree/2.0.0"
+                "source": "https://github.com/bigin/imanager/tree/2.0.1"
             },
-            "time": "2026-05-13T14:04:40+00:00"
+            "time": "2026-05-15T12:18:14+00:00"
         },
         {
             "name": "erusev/parsedown",
@@ -1386,5 +1386,5 @@
     "platform-overrides": {
         "php": "8.2.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -38,12 +38,6 @@ if [ ! -f "${DB_PATH}" ]; then
         echo "[entrypoint] extracting ${SEED_UPLOADS} into public/."
         su -s /bin/sh -c "tar xzf ${SEED_UPLOADS} -C public/" www-data
     fi
-    # `imanager dump` (sqlite3 .dump) silently skips FTS5 virtual tables, so
-    # the seed leaves items_fts missing even though schema_version says the
-    # FTS migration ran. Re-apply the migration SQL and repopulate the index.
-    echo "[entrypoint] recreating FTS5 index (dump skips virtual tables)."
-    su -s /bin/sh -c "sqlite3 ${DB_PATH} < vendor/bigins/imanager/config/schema/0002_fts.sql" www-data
-    su -s /bin/sh -c "vendor/bin/imanager fts:rebuild --db=${DB_PATH}" www-data
     echo "[entrypoint] seed restore complete."
 fi
 

--- a/docker/seed-demo.sql
+++ b/docker/seed-demo.sql
@@ -79,6 +79,68 @@ INSERT INTO "items" ("id", "category_id", "name", "label", "position", "active",
 INSERT INTO "items" ("id", "category_id", "name", "label", "position", "active", "data", "created", "updated") VALUES (8, 1, 'Getting Help', NULL, 8, 1, '{"menu_title":"Help","slug":"help","template":"","parent":6,"pagetype":"1","content":"...","images":null}', 1641818049, 1777793722);
 INSERT INTO "items" ("id", "category_id", "name", "label", "position", "active", "data", "created", "updated") VALUES (9, 2, 'admin', '', 1, 1, '{"role":"siteadmin","email":"gmail@chuck.norris.com","password":{"__class":"\\Imanager\\PasswordFieldValue","password":"$2y$10$gQdxIHrGm\/ia4RFzkoPXc.YmdpK87fbKGQIz.dXXhQuz0hwV4P\/C2","salt":""}}', 1519050932, 1777810723);
 
+-- Table: items_fts
+CREATE VIRTUAL TABLE items_fts USING fts5(
+    name,
+    label,
+    body,
+    tokenize = 'unicode61 remove_diacritics 2'
+);
+INSERT INTO "items_fts" ("rowid", "name", "label", "body") VALUES (1, 'Scriptor''s Demo Page', '', 'Scriptor''s Demo Page  scriptors-demo-page 0 1 Home Lorem markdownum notam sibila Argolicis habet, manibus illa, et. Fera vestigia
+metuunt annos ignibus *commota quippe*. Graiumque tua vix volanti Diomedeos
+lacrimis.
+
+### Urbe imbres qui laesaque
+
+Vestigia pallore. Matre quid dolore Acoetes sit videns frustraque retenta mare,
+caelestibus conamina coryli veloces.
+
+> Mariti cur: ante *causa* rigorem errabant gravitate imagine quotiensque amor
+> secundi cruribus [adclivi sibi est](http://caelestia.com/enim) apri dedimus
+> quinos. Mihi quoque gemelliparae factum gramen, alto nomina abest nostro,
+> illic extinctum regia, languescuntque. Anguis qui laesaque ciet nam lapsae,
+> *fortuna* manus at quam; in.
+
+### Highlighted code blocks
+
+```php
+echo $page->parsedown->text(
+    $page->content
+);
+```
+
+### Quibus sine velox
+
+Esse requiem pedes sub freta modo. Mortis **ieiunia furori animalia** credimus,
+terras per guttae paucaque coniuge in solas et illa sustinet? Antris proxima
+tantum lapidis Tonantis unde. Quoque sororis nivibus limine cognatumque
+pingebat, matre concentu Aeolides Cancri, ipsa terrae semper feci sanguine
+externos.
+
+- Acernas crescere et exitus
+- Silva deum Amphion tamen
+- Soror quondam contigit
+- Hamata modo quaerens ut velatam obmutuit decusque
+- Quam haererem aestatem ventos
+
+Incingere Aoniis celat imagine digitis et iram, cum est diu violave oculis passu
+meo. Sume in Cinyran aerane altrice amnis nefas gerebat properatis **orbem**
+sicco honorem ille bis. Repulsa quantaque aderat in relictas memoraverat arma
+desierant umerique, suo cum in nymphae signa praetemptatque suorum genetrici?
+Fieres sequitur quaeris Diana una parens, *te origo*; quid. Capherea liquitur
+mediis deerat facies agat quercu donavi Clara: Erinys Dies.   
+... default');
+INSERT INTO "items_fts" ("rowid", "name", "label", "body") VALUES (2, 'Articles', '', 'Articles  Articles articles blog 0 1 <!--
+This page functions as a container for blog posts. Any page within this container is identified as a blog post and utilized by the base template. The base template uses these pages to display blog content in a consistent and efficient manner.
+-->');
+INSERT INTO "items_fts" ("rowid", "name", "label", "body") VALUES (3, 'Get started with Scriptor', '', 'Get started with Scriptor  get-started-with-scriptor 2 1 Get started preserved default');
+INSERT INTO "items_fts" ("rowid", "name", "label", "body") VALUES (4, 'Contact', '', 'Contact  Contact contact contact 0 1 The basic theme comes with a built-in contact form, so that your site visitors can make all sorts of queries and contact. The contact form does not support SMTP by default, but you may easily extend it with e.g. Scriptor''s SMailer module, which does.');
+INSERT INTO "items_fts" ("rowid", "name", "label", "body") VALUES (5, 'Legal notice', '', 'Legal notice  Legal notice legal-notice  8 1 ...');
+INSERT INTO "items_fts" ("rowid", "name", "label", "body") VALUES (6, 'Footer Pages', '', 'Footer Pages  Footer Pages some-pages  0 1 This page is a container for all pages that should appear in the footer navigation.');
+INSERT INTO "items_fts" ("rowid", "name", "label", "body") VALUES (7, 'Privacy statement', '', 'Privacy statement  Privacy statement privacy-statement  8 1 ...');
+INSERT INTO "items_fts" ("rowid", "name", "label", "body") VALUES (8, 'Getting Help', '', 'Getting Help  Help help  8 1 ...');
+INSERT INTO "items_fts" ("rowid", "name", "label", "body") VALUES (9, 'admin', '', 'admin  siteadmin gmail@chuck.norris.com \Imanager\PasswordFieldValue $2y$10$gQdxIHrGm/ia4RFzkoPXc.YmdpK87fbKGQIz.dXXhQuz0hwV4P/C2 ');
+
 -- Table: schema_version
 CREATE TABLE schema_version (
                 version     INTEGER PRIMARY KEY,


### PR DESCRIPTION
Picks up the FTS5 dump fix from upstream
(https://github.com/bigin/imanager/pull/34).

Side-effects in this commit:
- docker/seed-demo.sql regenerated with the new dump command — now includes `CREATE VIRTUAL TABLE items_fts` and 9 INSERT rows with rowid preserved (so the FTS join to items.id round-trips).
- docker/entrypoint.sh: drop the post-restore FTS workaround (`sqlite3 < 0002_fts.sql` + `imanager fts:rebuild`) — the seed now restores the FTS table cleanly on its own.
- .gitattributes: pin docker/seed-demo.sql as -text so git's CRLF normalisation doesn't mangle CRLF sequences embedded in the page-content JSON; mark seed-demo-uploads.tar.gz binary while at it.

Verified locally with `down -v && up -d --build`: items_fts table present with 9 rows, item UPDATE round-trips without the "no such table: items_fts" crash that prompted the upstream fix.