### PR TITLE
docs(demo): refresh for SQL-dump seed + volume split + scriptor.cms c…

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,9 +1,10 @@
 # Scriptor 2.0 — demo image
 
 A one-command Docker stack to try Scriptor 2.0 without installing PHP,
-Composer, or SQLite locally. Builds a small `php:8.3-fpm-alpine` image
-with iManager 2.0, applies the schema migrations on first start, and
-seeds a minimal demo dataset (one admin user, one example page).
+Composer, or SQLite locally. Builds two small images
+(`php:8.3-fpm-alpine` for the app, `nginx:alpine` for the front) and
+restores a snapshot of the canonical Scriptor demo content on first
+start.
 
 > The image is meant for **trying the CMS**, not for production. It
 > bakes the demo seed into the entrypoint and ships with predictable
@@ -20,20 +21,19 @@ cd Scriptor
 docker compose up -d --build
 ```
 
-First boot takes a minute or two — Docker has to pull `php:8.3-fpm-alpine`
-+ `nginx:alpine` and Composer has to install dependencies inside the
-image. Subsequent starts are instant.
+First boot takes a minute or two — Docker has to pull
+`php:8.3-fpm-alpine` + `nginx:alpine` and Composer has to install
+dependencies inside the image. Subsequent starts are instant.
 
 Then open:
 
 | URL | What's there |
 |---|---|
-| **http://localhost:8080/** | The public front. The single seeded page rendered through Scriptor's default theme. |
+| **http://localhost:8080/** | The public front. The seeded `scriptor-cms.dev` content rendered through the default theme. |
 | **http://localhost:8080/editor/** | The editor. Sign in with the credentials below. |
 
-> **Port already in use?** If something else on the host (a local web
-> stack, another container) is already on `8080`, override the host
-> port via the `SCRIPTOR_DEMO_PORT` env var:
+> **Port already in use?** Override the host port via the
+> `SCRIPTOR_DEMO_PORT` env var:
 >
 > ```bash
 > SCRIPTOR_DEMO_PORT=8090 docker compose up -d --build
@@ -46,34 +46,37 @@ Then open:
 
 ```
 username: admin
-password: scriptor
+password: gT5nLazzyBob
 ```
 
-The credentials are baked into the seed and intentionally short — change
-them immediately if you expose the container beyond your machine.
+The credentials are baked into the seed snapshot — change them
+immediately if you expose the container beyond your machine.
 
 ---
 
-## What the seed creates
+## What the seed restores
 
 The first time the container starts (no SQLite database yet) the
-entrypoint runs `vendor/bin/imanager schema:migrate` and then
-`docker/seed-demo.php`, which creates:
+entrypoint loads two seed artefacts shipped with the repo:
 
-- **`Pages` category** + 7 fields: `slug`, `parent`, `pagetype`,
-  `menu_title`, `content`, `template`, `images`.
-- **`Users` category** + 3 fields: `role`, `email`, `password`.
-- One **admin user** (`admin` / `scriptor`).
-- One **example page** (`hello-world`) rendered at `/`.
+- `docker/seed-demo.sql` — sqlite3 dump captured via
+  `vendor/bin/imanager dump`. Restores schema + every category, field,
+  page, file row, and the FTS5 index for full-text search.
+- `docker/seed-demo-uploads.tar.gz` — `public/uploads/` for the page
+  images referenced from the dump.
 
-The seed is idempotent — restarting the container re-applies any
-pending iManager migrations but does **not** re-seed data.
+After the restore, `vendor/bin/imanager schema:migrate` runs as a
+no-op (or applies any newer migrations the snapshot didn't include).
+
+The seed snapshot mirrors `https://scriptor.cms` content as of the
+last `chore(deps): bump bigins/imanager` PR. Restarts re-apply
+pending iManager migrations but do **not** re-seed data — the
+SQLite DB and uploads live in named volumes that survive
+`docker compose down`.
 
 ---
 
 ## Trying things
-
-A handful of explorations that show off the moving parts:
 
 ### Add a page through the editor
 
@@ -90,8 +93,8 @@ docker compose exec scriptor sqlite3 data/imanager.db \
   "SELECT i.id, i.name, c.slug FROM items i JOIN categories c ON c.id = i.category_id;"
 ```
 
-You should see your seeded page, the admin user, and anything you've
-created through the editor.
+You should see all seeded pages, the admin user, and anything
+you've created through the editor.
 
 ### Run the iManager CLI
 
@@ -111,23 +114,27 @@ docker compose down -v
 docker compose up -d
 ```
 
-`down -v` removes the named volume, which is where the SQLite DB and
-the uploads live — the next `up` re-seeds.
+`down -v` removes the named volumes (`scriptor-data` for the SQLite
+DB + cache/logs, `scriptor-uploads` for `public/uploads/`) — the next
+`up` re-seeds.
 
 ---
 
 ## What lives where
 
-| In the container | Purpose |
-|---|---|
-| `/var/www/scriptor/` | Application code + `vendor/`. |
-| `/var/www/scriptor/data/imanager.db` | SQLite DB (+ WAL sidecars). |
-| `/var/www/scriptor/data/uploads-2.0/` | Item file attachments. |
-| `/var/www/scriptor/data/cache/sections/` | PSR-16 fragment cache. |
+Post the 2026-05-15 volume split, code lives in the **images**
+(rebuilt fresh on every `up -d --build`); only mutable state is in
+named volumes:
 
-The whole `/var/www/scriptor/` directory is on the named volume
-`scriptor-app`. Both services (php-fpm and nginx) mount it — nginx
-read-only.
+| Path in container | Source | Purpose |
+|---|---|---|
+| `/var/www/scriptor/` (everything except below) | image | Application code, vendor/, baked public/ |
+| `/var/www/scriptor/data/` | volume `scriptor-data` | SQLite DB (+ WAL), cache, logs, settings |
+| `/var/www/scriptor/public/uploads/` | volume `scriptor-uploads` | FileStorage |
+
+This split means `git pull && docker compose up -d --build`
+propagates code changes; the DB and uploads survive container
+recreation.
 
 ---
 
@@ -135,19 +142,39 @@ read-only.
 
 | File | Role |
 |---|---|
-| `docker/Dockerfile` | `php:8.3-fpm-alpine` + iManager extensions + production-shaped opcache + composer install with VCS-overridden iManager dep. |
-| `docker/nginx.conf` | Front-controller routing; serves `/data/uploads-2.0/` directly; blocks the rest of `data/` and any stray `imanager/`. |
-| `docker/entrypoint.sh` | Applies schema migrations on every start; seeds on first start (no DB present). |
-| `docker/seed-demo.php` | Idempotent seed (Pages + Users categories, admin user, example page). |
+| `docker/Dockerfile` | `php:8.3-fpm-alpine` + iManager extensions + opcache + composer install of `bigins/imanager` from Packagist. |
+| `docker/Dockerfile.web` | `nginx:alpine` with `public/` baked in so SCRIPT_FILENAME paths resolve identically in both containers. |
+| `docker/nginx.conf` | Front-controller routing; serves `/uploads/` directly; blocks dotfiles + any stray non-`index.php` PHP. |
+| `docker/entrypoint.sh` | On every start: `schema:migrate` (idempotent). On first start (no DB): restore seed + extract uploads. |
+| `docker/seed-demo.sql` | Database snapshot — schema + every page, field, file row, FTS5 index. |
+| `docker/seed-demo-uploads.tar.gz` | `public/uploads/` snapshot for page images referenced by the dump. |
 | `docker-compose.yml` | Two-service stack on `http://localhost:8080`. |
+
+---
+
+## Refreshing the seed when scriptor.cms content evolves
+
+```bash
+# In a working copy connected to the canonical scriptor.cms DB:
+vendor/bin/imanager dump --db=data/imanager.db > docker/seed-demo.sql
+
+# And the upload subdirs the dump references:
+COPYFILE_DISABLE=1 tar --format=ustar -czf docker/seed-demo-uploads.tar.gz \
+  -C public uploads/<referenced-subdirs>
+```
+
+Referenced subdirs come from
+`SELECT DISTINCT substr(path, 1, instr(path, '/') - 1) FROM files;`
+on the canonical DB. Use `ustar` format so alpine busybox tar
+doesn't warn about pax extended headers.
 
 ---
 
 ## When NOT to use this
 
-- **Production.** The demo image bakes `admin / scriptor` into the
-  seed and runs with `opcache.validate_timestamps = 1` (handy for
-  exploration, wrong for production throughput). For a real
+- **Production.** The demo image bakes `admin / gT5nLazzyBob` into
+  the seed and runs with `opcache.validate_timestamps = 1` (handy
+  for exploration, wrong for production throughput). For a real
   deployment, follow the
   [iManager deployment guide](https://github.com/bigin/imanager/blob/main/docs/deployment.md)
   and write your own Dockerfile.


### PR DESCRIPTION
…ontent

The demo.md write-up dated from when the container seeded "Hello, world" programmatically against a single scriptor-app volume with admin/scriptor credentials. None of that is true anymore.

Brings the doc current with:
- Two-image stack (php-fpm + Dockerfile.web nginx with public/ baked in)
- SQL-dump seed (docker/seed-demo.sql + seed-demo-uploads.tar.gz) mirroring scriptor.cms instead of programmatic Hello-world
- Volume split (scriptor-data + scriptor-uploads) — code from images
- Credentials admin/gT5nLazzyBob (matches the seed snapshot)
- Filesystem layout: public/uploads/ (post public/-webroot refactor), not data/uploads-2.0/
- New section on refreshing the seed when scriptor.cms content evolves