### PR TITLE
chore(composer): drop "flat file" keyword, refresh description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "bigins/scriptor",
     "type": "project",
-    "description": "Scriptor CMS/CMF",
-    "keywords": ["scriptor", "cms", "cmf", "flat file"],
+    "description": "Lightweight PHP CMS for microsites, blogs and wikis — SQLite + FTS5 search, Markdown, rich-text editing.",
+    "keywords": ["scriptor", "cms", "cmf", "php", "sqlite", "markdown", "microsite", "blog", "wiki"],
     "license": "MIT",
     "homepage": "https://scriptor-cms.dev",
     "authors": [


### PR DESCRIPTION
Packagist indexes both fields. "flat file" stopped being true at 2.0 — storage is SQLite + FTS5 — and the description was a placeholder ("Scriptor CMS/CMF") that told prospective users nothing. Switch to a keyword set that reflects 2.0 (sqlite, markdown, microsite, blog, wiki) and a description that matches the GitHub About and README intro.