### PR TITLE
docs(readme): rewrite the "library" example to match the real surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,14 +170,25 @@ docs/                        themes.md, install-shared-hosting.md, …
 <?php
 
 use Scriptor\Boot\App;
-use Scriptor\Boot\ImanagerBootstrap;
-use Imanager\Storage\ItemRepository;
+use Scriptor\Boot\Frontend\Site;
 
-require __DIR__ . '/vendor/autoload.php';
+// Loads the autoloader, builds the iManager container on App::container(),
+// and populates $config from data/settings/scriptor-config.php.
+require __DIR__ . '/boot.php';
 
-App::set(ImanagerBootstrap::create(__DIR__));   // __DIR__ = the Scriptor root
+$site = new Site(App::container(), $config, __DIR__);
 
-$item = App::container()->get(ItemRepository::class)->find(1);
+// Data access — read pages directly off the Pages category:
+$home = $site->pages()->findHome();          // or ->findBySlug('contact')
+echo $home->name;                            // page title
+echo $home->content;                         // markdown source
+
+// Theme rendering — resolves $_SERVER['REQUEST_URI'] to a Page and
+// returns the same fragments the bundled themes' template.php consumes.
+// Call from your own front controller:
+$site->execute();
+echo $site->render('content');               // page body, rendered + cached
+echo $site->render('navigation');            // theme nav
 ```
 
 See `boot/Frontend/Site.php` for the full set of services the bundled


### PR DESCRIPTION
The old snippet handed the reader an opaque \$item via iManager's low-level ItemRepository->find(1). Three things wrong with that:
1. \$item is the abstract polytype — page/user/file/whatever. The reader doesn't know what they got.
2. ID 1 is magic; a fresh install may not even have it.
3. "Use Scriptor as a library" framing was undermined by reaching straight into iManager instead of using Scriptor's own surface.

Switch to require boot.php (single line — autoloader, container, \$config all set up). Then show the two natural library use-cases end-to-end: page data access via \$site->pages()->findHome(), and theme rendering via \$site->execute() + \$site->render(). Both smoke-tested against the live DB.