### PR TITLE
chore(deps): bump bigins/imanager 2.0.2 -> 2.1.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "bigins/imanager",
-            "version": "2.0.2",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bigin/imanager.git",
-                "reference": "db9d2bdff57f923fcf5cbfaea3e7cabd563a6fee"
+                "reference": "f38bce72e10aa5011eed08250bd1d352e301a4d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bigin/imanager/zipball/db9d2bdff57f923fcf5cbfaea3e7cabd563a6fee",
-                "reference": "db9d2bdff57f923fcf5cbfaea3e7cabd563a6fee",
+                "url": "https://api.github.com/repos/bigin/imanager/zipball/f38bce72e10aa5011eed08250bd1d352e301a4d8",
+                "reference": "f38bce72e10aa5011eed08250bd1d352e301a4d8",
                 "shasum": ""
             },
             "require": {
@@ -83,9 +83,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bigin/imanager/issues",
-                "source": "https://github.com/bigin/imanager/tree/2.0.2"
+                "source": "https://github.com/bigin/imanager/tree/2.1.0"
             },
-            "time": "2026-05-16T09:31:38+00:00"
+            "time": "2026-05-16T18:46:17+00:00"
         },
         {
             "name": "erusev/parsedown",


### PR DESCRIPTION
iManager 2.1.0 shipped on 2026-05-16 with the schema-setup ergonomics surface (16 Field::* static factories, 13 fluent setters, CategoryRepository::ensure() + FieldRepository::ensure() upsert-by-natural-key) plus the corrected Imanager::VERSION constant and the new ReleaseConsistencyTest that gates future forgotten bumps.

Lock now resolves bigins/imanager: ^2.0 to 2.1.0 (commit f38bce7 = the chore(release): cut 2.1.0 merge). Scriptor's own code can now use Field::text(...)->required()->indexed() and $fields->ensure(...) in any future schema-setup work, instead of the verbose new Field(null, $cat->id, 'name', 'Label', FieldType::Text, required: true, ...) constructors.

Local boot smoke: Imanager::VERSION reports 2.1.0; Field::text reflects on Imanager\Domain\Field. Live smoke against the currently-deployed scriptor.cms: frontend 200, editor auth page 200 (unchanged since this PR only bumps the lock, no Scriptor code change).

No Scriptor source uses the new surface yet — that comes when schema-touching work happens. This PR is the enabler.