### PR TITLE
chore(deps): bump bigins/imanager 2.1.0 -> 2.2.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "bigins/imanager",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bigin/imanager.git",
-                "reference": "f38bce72e10aa5011eed08250bd1d352e301a4d8"
+                "reference": "421aabb38bf252743bc8e4f2847e6be1abbca790"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bigin/imanager/zipball/f38bce72e10aa5011eed08250bd1d352e301a4d8",
-                "reference": "f38bce72e10aa5011eed08250bd1d352e301a4d8",
+                "url": "https://api.github.com/repos/bigin/imanager/zipball/421aabb38bf252743bc8e4f2847e6be1abbca790",
+                "reference": "421aabb38bf252743bc8e4f2847e6be1abbca790",
                 "shasum": ""
             },
             "require": {
@@ -83,9 +83,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bigin/imanager/issues",
-                "source": "https://github.com/bigin/imanager/tree/2.1.0"
+                "source": "https://github.com/bigin/imanager/tree/2.2.0"
             },
-            "time": "2026-05-16T18:46:17+00:00"
+            "time": "2026-05-17T09:35:29+00:00"
         },
         {
             "name": "erusev/parsedown",


### PR DESCRIPTION
Pulls in the honest searchable-flag release. Scriptor's existing 8 text-typed fields (slug, parent, pagetype, menu_title, content, template, role, email) were promoted to searchable=1 via the iManager 0005 migration; password + images stay opted out.

Upgrade on the live install (scriptor.cms):
  vendor/bin/imanager schema:migrate --db=data/imanager.db
  vendor/bin/imanager fts:rebuild   --db=data/imanager.db

Pre-bump DB snapshot kept locally at data/imanager.db.pre-22-bump (gitignored). Smoked: frontend 200, editor 200, search 200.