### PR TITLE
fix(docker/entrypoint): tolerate read-only bind-mounted config files

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -24,7 +24,12 @@ cd "${APP_DIR}"
 # attach — fix that here rather than failing later.
 mkdir -p data data/cache data/cache/sections data/logs data/backups data/settings public/uploads
 if [ "$(id -u)" = "0" ]; then
-    chown -R www-data:www-data data public/uploads
+    # `|| :` swallows EROFS on bind-mounted read-only config files
+    # (e.g. an operator overlaying a custom.scriptor-config.php inside
+    # data/settings/). The writable paths still get chowned; the
+    # read-only entries we couldn't touch were owner-correct to begin
+    # with, since the operator mounted them.
+    chown -R www-data:www-data data public/uploads 2>/dev/null || :
 fi
 
 if [ ! -f "${DB_PATH}" ]; then


### PR DESCRIPTION
The first-boot `chown -R www-data:www-data data public/uploads` ran under `set -eu`, so any read-only file inside `data/` (e.g. an operator overlaying `data/settings/custom.scriptor-config.php` via a docker `:ro` bind-mount) tripped EROFS and crashed the entrypoint before the seed import. The container then restart-looped, never reached its healthcheck, and any dependent service stayed pending.

Discovered on the scriptor-cms.dev deploy (bigin/scriptor-cms-ops PR #8), where the site bundle bind-mounts two ro config files into data/settings/ on first boot.

Fix: pipe chown stderr to /dev/null and `|| :` the failure. Writable paths still get the right owner; the read-only entries the operator mounted were owner-correct to begin with (they came from a deliberate bind-mount), so swallowing the EROFS is safe.