### PR TITLE
fix(nginx): allow blob: workers in CSP for FilePond

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -37,8 +37,13 @@ http {
     # shadowed when an inner location declares its own add_header — so
     # locations that need a per-location header (e.g. /uploads/ for
     # Cache-Control) repeat the security set below.
+    # `worker-src 'self' blob:` is needed by FilePond, which spawns
+    # off-thread workers from `blob:`-URLs for client-side image
+    # processing (resize, EXIF strip). Without it, browsers fall back
+    # to `script-src`, which doesn't allow `blob:` — uploads still
+    # work, but the worker creation throws on every file pick.
     map $sent_http_content_type $scriptor_security_csp {
-        default "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self' https://cdn.jsdelivr.net data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self'; form-action 'self'";
+        default "default-src 'self'; script-src 'self' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: blob:; font-src 'self' https://cdn.jsdelivr.net data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'self'; form-action 'self'";
     }
 
     server {


### PR DESCRIPTION
The editor's upload widget (FilePond) spawns off-thread workers from `blob:` URLs to resize + EXIF-strip images on the client before they hit the server. The bundled CSP locked `script-src` to `'self' + https://cdn.jsdelivr.net`, and didn't set `worker-src` at all — so browsers fell back to `script-src`, which rejects `blob:`. The worker creation threw on every file pick:

  Creating a worker from 'blob:http://…/<uuid>' violates the
  following Content Security Policy directive: "script-src 'self'
  https://cdn.jsdelivr.net". Note that 'worker-src' was not
  explicitly set, so 'script-src' is used as a fallback.

Fix: add an explicit `worker-src 'self' blob:` directive. Narrow enough to keep the rest of the CSP unchanged — `script-src` itself still doesn't accept `blob:` for regular script tags; only Worker / SharedWorker / ServiceWorker construction does.

Smoke
- Local Docker stack: `docker compose ... restart web` (the bind-mount on macOS needs the restart because the file inode changes on Write), then `curl -sI http://localhost:8090/` shows the new directive in the Content-Security-Policy response header.
- FilePond's worker error gone, image uploads complete.

Hetzner upgrade
- `cd /opt/scriptor-cms.dev && git pull --ff-only && docker compose ... up -d --build` picks up the new nginx.conf via the recreated `web` container. demos.scriptor-cms.dev inherits the same fix from its next `up -d --build` against this master.