### PR TITLE
feat(plugin): plugin discovery + lifecycle (Phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /data/imanager.db-wal
 /data/imanager.db-shm
 /data/cache/sections/
+/data/cache/plugins.php
 
 # User uploads — live under the webroot (public/uploads/) so the web
 # server can serve them directly, but are runtime state and not part

--- a/boot.php
+++ b/boot.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Scriptor\Boot\App;
 use Scriptor\Boot\ImanagerBootstrap;
+use Scriptor\Boot\Plugin\PluginManager;
 
 require __DIR__ . '/vendor/autoload.php';
 
@@ -14,7 +15,9 @@ App::set(ImanagerBootstrap::create(__DIR__));
  *   - vendor/autoload.php (Composer + iManager 2.0)
  *   - iManager container set on App::container()
  *   - $config loaded from data/settings/scriptor-config.php (file format
- *     unchanged — themes still read it from $site->config)
+ *     unchanged; themes still read it from $site->config)
+ *   - Plugin discovery + boot. Plugins register against PluginContext
+ *     before any routing or rendering. See docs/scriptor-plugin-api-plan.md.
  */
 
 // scriptor-config.php still guards its first line with `defined('IS_IM')`,
@@ -32,3 +35,12 @@ if (file_exists(__DIR__ . '/data/settings/custom.scriptor-config.php')) {
         include __DIR__ . '/data/settings/custom.scriptor-config.php',
     );
 }
+
+$pluginManager = new PluginManager(
+    container:  App::container(),
+    vendorDir:  __DIR__ . '/vendor',
+    cachePath:  __DIR__ . '/data/cache/plugins.php',
+    disabled:   (array) ($config['plugins']['disabled'] ?? []),
+);
+$pluginManager->bootAll();
+App::container()->add(PluginManager::class, $pluginManager);

--- a/boot/Plugin/Plugin.php
+++ b/boot/Plugin/Plugin.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Plugin;
+
+/**
+ * Contract every Scriptor plugin implements.
+ *
+ * Plugins are composer packages with `"type": "scriptor-plugin"` in their
+ * own composer.json plus an `extra.scriptor.plugin` FQCN pointing at an
+ * implementor of this interface. The {@see PluginManager} discovers
+ * them at boot time and calls {@see register()} on each.
+ *
+ * `register()` is the only place where the framework hands control to
+ * plugin code at boot. Anything the plugin wants to influence (DI
+ * bindings, event subscriptions, editor modules, menu items) goes
+ * through the {@see PluginContext} passed in. Plugins do not reach
+ * into framework internals directly.
+ */
+interface Plugin
+{
+    /** Human-readable identifier; shown in logs and the future editor surface. */
+    public function name(): string;
+
+    /** Semantic version. Informational only; the loader does not enforce constraints. */
+    public function version(): string;
+
+    /**
+     * Register the plugin against the application surface. Called once
+     * per request, after the iManager container is booted, before any
+     * routing or rendering happens.
+     */
+    public function register(PluginContext $context): void;
+}

--- a/boot/Plugin/PluginContext.php
+++ b/boot/Plugin/PluginContext.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Plugin;
+
+use League\Container\Container;
+
+/**
+ * Registration surface handed to every plugin's {@see Plugin::register()}.
+ *
+ * Phase 2 exposes only the DI container. Plugins can bind services
+ * (`$context->container()->add(MyService::class)`) and resolve
+ * framework services they need. Subsequent phases extend this surface:
+ *
+ * - Phase 3 adds `subscribe(string $event, callable $handler)` for
+ *   PSR-14 frontend event subscriptions.
+ * - Phase 4 adds `registerEditorModule()` and `addEditorMenuItem()`
+ *   for editor extension hooks.
+ *
+ * The context mediates every registration so the underlying wiring
+ * can change without breaking plugins on every refactor.
+ */
+final class PluginContext
+{
+    public function __construct(
+        private readonly Container $container,
+    ) {}
+
+    public function container(): Container
+    {
+        return $this->container;
+    }
+}

--- a/boot/Plugin/PluginManager.php
+++ b/boot/Plugin/PluginManager.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Plugin;
+
+use League\Container\Container;
+
+/**
+ * Discovers Scriptor plugins from composer's installed.json and boots
+ * them once per request.
+ *
+ * Discovery rules (matches the plan in `docs/scriptor-plugin-api-plan.md`):
+ *
+ * - A plugin package declares `"type": "scriptor-plugin"` in its
+ *   composer.json.
+ * - The same composer.json carries the plugin FQCN under
+ *   `extra.scriptor.plugin`.
+ * - The FQCN must implement {@see Plugin}.
+ *
+ * Discovery results land in a PHP cache file (default
+ * `data/cache/plugins.php`) so the installed.json scan does not run
+ * on every request. Composer post-install / post-update scripts can
+ * call {@see clearCache()} to invalidate after dependency changes;
+ * in development a missing cache simply means one slow boot.
+ *
+ * Disabling a discovered plugin without uninstalling it is possible
+ * via `$config['plugins']['disabled']` in scriptor-config.php; the
+ * array carries FQCNs that this manager skips at boot.
+ */
+final class PluginManager
+{
+    /** @var list<PluginManifest>|null Lazy-populated by {@see discover()}. */
+    private ?array $manifests = null;
+
+    /** @var list<Plugin> */
+    private array $bootedPlugins = [];
+
+    /**
+     * @param list<string> $disabled FQCNs of plugins to skip at boot.
+     */
+    public function __construct(
+        private readonly Container $container,
+        private readonly string $vendorDir,
+        private readonly string $cachePath,
+        private readonly array $disabled = [],
+    ) {}
+
+    /**
+     * Returns the discovered plugin manifests, using the cache when
+     * available. Pass `forceRefresh: true` to bypass the cache and
+     * re-scan installed.json.
+     *
+     * @return list<PluginManifest>
+     */
+    public function discover(bool $forceRefresh = false): array
+    {
+        if ($this->manifests !== null && ! $forceRefresh) {
+            return $this->manifests;
+        }
+
+        if (! $forceRefresh) {
+            $cached = $this->readCache();
+            if ($cached !== null) {
+                $this->manifests = $cached;
+                return $cached;
+            }
+        }
+
+        $manifests = $this->scanInstalledJson();
+        $this->manifests = $manifests;
+        $this->writeCache($manifests);
+        return $manifests;
+    }
+
+    /**
+     * Instantiate every discovered plugin (skipping disabled ones),
+     * call {@see Plugin::register()}. Idempotent: subsequent calls
+     * within the same request are a no-op.
+     */
+    public function bootAll(): void
+    {
+        if ($this->bootedPlugins !== []) {
+            return;
+        }
+        $context = new PluginContext($this->container);
+        foreach ($this->discover() as $manifest) {
+            if (in_array($manifest->pluginClass, $this->disabled, true)) {
+                continue;
+            }
+            if (! class_exists($manifest->pluginClass)) {
+                continue;
+            }
+            $instance = new $manifest->pluginClass();
+            if (! $instance instanceof Plugin) {
+                continue;
+            }
+            $instance->register($context);
+            $this->bootedPlugins[] = $instance;
+        }
+    }
+
+    /** @return list<Plugin> */
+    public function bootedPlugins(): array
+    {
+        return $this->bootedPlugins;
+    }
+
+    /**
+     * Clear the discovery cache. Composer post-install / post-update
+     * scripts should call this so the next boot re-scans installed.json
+     * and picks up plugin add/remove.
+     */
+    public function clearCache(): void
+    {
+        if (is_file($this->cachePath)) {
+            @unlink($this->cachePath);
+        }
+        $this->manifests = null;
+    }
+
+    /**
+     * @return list<PluginManifest>
+     */
+    private function scanInstalledJson(): array
+    {
+        $installed = $this->vendorDir . '/composer/installed.json';
+        if (! is_file($installed)) {
+            return [];
+        }
+        $raw = file_get_contents($installed);
+        if ($raw === false) {
+            return [];
+        }
+        $data = json_decode($raw, true);
+        if (! is_array($data)) {
+            return [];
+        }
+
+        // Composer 2 wraps packages in {"packages": [...]}, Composer 1
+        // shipped a flat list. Support both for forward-compatibility
+        // with any tooling that regenerates installed.json oddly.
+        $packages = isset($data['packages']) && is_array($data['packages'])
+            ? $data['packages']
+            : $data;
+
+        $manifests = [];
+        foreach ($packages as $package) {
+            if (! is_array($package)) {
+                continue;
+            }
+            if (($package['type'] ?? null) !== 'scriptor-plugin') {
+                continue;
+            }
+            $class = $package['extra']['scriptor']['plugin'] ?? null;
+            if (! is_string($class) || $class === '') {
+                continue;
+            }
+            $manifests[] = new PluginManifest(
+                packageName: (string) ($package['name'] ?? 'unknown'),
+                packageVersion: (string) ($package['version'] ?? '0.0.0'),
+                pluginClass: $class,
+            );
+        }
+        return $manifests;
+    }
+
+    /**
+     * @return list<PluginManifest>|null
+     */
+    private function readCache(): ?array
+    {
+        if (! is_file($this->cachePath)) {
+            return null;
+        }
+        $cached = @include $this->cachePath;
+        if (! is_array($cached)) {
+            return null;
+        }
+        $manifests = [];
+        foreach ($cached as $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+            $manifests[] = new PluginManifest(
+                packageName:    (string) ($entry['packageName']    ?? 'unknown'),
+                packageVersion: (string) ($entry['packageVersion'] ?? '0.0.0'),
+                pluginClass:    (string) ($entry['pluginClass']    ?? ''),
+            );
+        }
+        return $manifests;
+    }
+
+    /**
+     * @param list<PluginManifest> $manifests
+     */
+    private function writeCache(array $manifests): void
+    {
+        $dir = dirname($this->cachePath);
+        if (! is_dir($dir) && ! @mkdir($dir, 0o775, true) && ! is_dir($dir)) {
+            return;
+        }
+        $payload = array_map(
+            static fn (PluginManifest $m): array => [
+                'packageName'    => $m->packageName,
+                'packageVersion' => $m->packageVersion,
+                'pluginClass'    => $m->pluginClass,
+            ],
+            $manifests,
+        );
+        $php = "<?php\n\n// Generated by Scriptor\\Boot\\Plugin\\PluginManager.\n"
+             . "// Delete this file or call PluginManager::clearCache() after\n"
+             . "// composer install/update so new plugins are picked up.\n\n"
+             . 'return ' . var_export($payload, true) . ";\n";
+        @file_put_contents($this->cachePath, $php);
+    }
+}

--- a/boot/Plugin/PluginManifest.php
+++ b/boot/Plugin/PluginManifest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Plugin;
+
+/**
+ * A single entry from composer's installed.json that names a Scriptor
+ * plugin. The {@see PluginManager} stores these in its discovery
+ * cache so the JSON scan only runs once per cache-bust.
+ */
+final readonly class PluginManifest
+{
+    public function __construct(
+        public string $packageName,
+        public string $packageVersion,
+        public string $pluginClass,
+    ) {}
+}


### PR DESCRIPTION
First chunk of the Scriptor Plugin API laid out in docs/scriptor-plugin-api-plan.md. Ships the discovery mechanism and boot wiring; events (Phase 3) and editor hooks (Phase 4) land in follow-up PRs. No theme or first-party plugin changes yet, so the existing render path is untouched.

What lands:

- boot/Plugin/Plugin.php Contract every plugin implements: name(), version(), register().

- boot/Plugin/PluginContext.php Registration surface passed to each plugin's register(). Phase 2 exposes the DI container only; subscribe()/registerEditorModule() land in Phase 3 and Phase 4 respectively.

- boot/Plugin/PluginManifest.php Tiny DTO carrying the discovered package name, version, and plugin FQCN. Used as the cache record.

- boot/Plugin/PluginManager.php Scans vendor/composer/installed.json for packages with type:"scriptor-plugin" and an extra.scriptor.plugin FQCN. Caches the list to data/cache/plugins.php so installed.json is only parsed once per cache bust. bootAll() instantiates every discovered (and not-disabled) plugin and calls register(). clearCache() lets composer post-install/update scripts invalidate the cache. Disabled plugins are filtered by FQCN via $config['plugins']['disabled'].

- boot.php After config load, instantiates PluginManager, calls bootAll(), registers it with the container so downstream code can resolve it.

- .gitignore /data/cache/plugins.php is a runtime artifact, never commit.

Smoke (CLI fixture; no docker rebuild needed for verification):

  $ php -r 'require "boot.php";
            $pm = Scriptor\Boot\App::container()->get(
              Scriptor\Boot\Plugin\PluginManager::class);
            echo count($pm->discover()) . " plugins\n";'
  → 0 plugins (correct on bare install)

  Full fixture run with a synthetic installed.json:
    Discovered: 1 (correct, library packages filtered out)
    Booted: 1, register() callback fired
    Cache survives installed.json deletion (cache hit on 2nd discover)
    Disable list applied: 0 booted (FQCN filter works)

Open in Phase 3:
- Frontend PSR-14 events (PageResolving, PageResolved, ContentRendering, Rendered, RouteNotFound)
- DbPagesResolverPlugin shows the dispatch in action by making the built-in DB slug lookup a registered event subscriber.

Plan reference: docs/scriptor-plugin-api-plan.md, sections 3.1-3.4.