### PR TITLE
feat(plugin): PSR-14 frontend events + DbPagesResolverPlugin (Phase 3)

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -10,6 +10,19 @@ require __DIR__ . '/vendor/autoload.php';
 
 App::set(ImanagerBootstrap::create(__DIR__));
 
+// Scriptor's frontend Page repository sits one layer above iManager's
+// storage repositories. Bind it once so anything in the request
+// pipeline (Site, plugins, modules) can resolve the same instance via
+// the container instead of newing one up themselves.
+App::container()->addShared(
+    \Scriptor\Boot\Frontend\PageRepository::class,
+    static fn(): \Scriptor\Boot\Frontend\PageRepository
+        => new \Scriptor\Boot\Frontend\PageRepository(
+            App::container()->get(\Imanager\Storage\CategoryRepository::class),
+            App::container()->get(\Imanager\Storage\ItemRepository::class),
+        ),
+);
+
 /*
  * Boot path:
  *   - vendor/autoload.php (Composer + iManager 2.0)
@@ -37,10 +50,18 @@ if (file_exists(__DIR__ . '/data/settings/custom.scriptor-config.php')) {
 }
 
 $pluginManager = new PluginManager(
-    container:  App::container(),
-    vendorDir:  __DIR__ . '/vendor',
-    cachePath:  __DIR__ . '/data/cache/plugins.php',
-    disabled:   (array) ($config['plugins']['disabled'] ?? []),
+    container:   App::container(),
+    vendorDir:   __DIR__ . '/vendor',
+    cachePath:   __DIR__ . '/data/cache/plugins.php',
+    disabled:    (array) ($config['plugins']['disabled'] ?? []),
+    corePlugins: [
+        // Built-in DB slug resolver. Sits behind the same PageResolving
+        // event that third-party plugins subscribe to so the dispatch
+        // pipeline is uniform. Operators can disable this by adding the
+        // FQCN to $config['plugins']['disabled'] (for a headless site
+        // that only resolves pages through a custom resolver plugin).
+        \Scriptor\Boot\Plugin\CorePlugins\DbPagesResolverPlugin::class,
+    ],
 );
 $pluginManager->bootAll();
 App::container()->add(PluginManager::class, $pluginManager);

--- a/boot/Events/Frontend/PageResolved.php
+++ b/boot/Events/Frontend/PageResolved.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Events\Frontend;
+
+use Scriptor\Boot\Frontend\Page;
+
+/**
+ * Dispatched after a page has been resolved (either by a plugin via
+ * {@see PageResolving} or by the built-in fall-through). Read-only:
+ * subscribers cannot change the result here; they can only react
+ * (logging, ACL checks that throw, breadcrumb building).
+ */
+final readonly class PageResolved
+{
+    public function __construct(
+        public Page $page,
+    ) {}
+}

--- a/boot/Events/Frontend/PageResolving.php
+++ b/boot/Events/Frontend/PageResolving.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Events\Frontend;
+
+use Imanager\Http\UrlSegments;
+use Scriptor\Boot\Frontend\Page;
+
+/**
+ * Dispatched at the start of {@see Scriptor\Boot\Frontend\Site::execute()}
+ * so plugins can resolve the requested URL to a page before the built-in
+ * lookup runs.
+ *
+ * Listeners cooperate via the mutable {@see $resolution} slot: the first
+ * listener to set a non-null Page wins, subsequent listeners are expected
+ * to self-check and skip if the slot is already filled. Site picks up
+ * whatever is in the slot after all listeners have run and treats it as
+ * the resolved page; if the slot is still null, Site falls through to its
+ * remaining built-in logic (which in Phase 3 is mostly an empty path
+ * because the DB slug lookup has moved into DbPagesResolverPlugin).
+ *
+ * Conventional listener body:
+ *
+ *     function (PageResolving $event): void {
+ *         if ($event->resolution !== null) return;       // someone already resolved
+ *         $page = $this->mySource->find($event->urlSegments);
+ *         if ($page !== null) {
+ *             $event->resolution = $page;
+ *         }
+ *     }
+ */
+final class PageResolving
+{
+    public ?Page $resolution = null;
+
+    public function __construct(
+        public readonly UrlSegments $urlSegments,
+    ) {}
+}

--- a/boot/Events/Frontend/RouteNotFound.php
+++ b/boot/Events/Frontend/RouteNotFound.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Events\Frontend;
+
+use Imanager\Http\UrlSegments;
+use Scriptor\Boot\Frontend\Page;
+
+/**
+ * Last-chance event before {@see Scriptor\Boot\Frontend\Site::throw404()}
+ * actually renders the 404 page. Listeners get the same cooperative
+ * resolution slot as {@see PageResolving}: if anyone sets a non-null
+ * Page, Site treats the request as resolved after all and skips the
+ * 404 path.
+ *
+ * Typical use: a plugin that wants to handle deep dynamic paths but
+ * does not want to claim resolution authority for every URL upfront.
+ * It subscribes to RouteNotFound and only matches the patterns it
+ * cares about, leaving everything else to the standard 404 flow.
+ */
+final class RouteNotFound
+{
+    public ?Page $resolution = null;
+
+    public function __construct(
+        public readonly UrlSegments $urlSegments,
+    ) {}
+}

--- a/boot/Frontend/Site.php
+++ b/boot/Frontend/Site.php
@@ -13,6 +13,10 @@ use Imanager\Storage\FileRepository;
 use Imanager\Templating\TemplateRenderer;
 use Imanager\Validation\Sanitizer as ImanagerSanitizer;
 use League\Container\Container;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Scriptor\Boot\Events\Frontend\PageResolved;
+use Scriptor\Boot\Events\Frontend\PageResolving;
+use Scriptor\Boot\Events\Frontend\RouteNotFound;
 
 /**
  * Frontend renderer for the public Scriptor site, replacing the legacy
@@ -88,10 +92,7 @@ class Site
     ) {
         $this->config = $config;
         $this->sanitizer = new Sanitizer($container->get(ImanagerSanitizer::class));
-        $this->pages = new PageRepository(
-            $container->get(\Imanager\Storage\CategoryRepository::class),
-            $container->get(\Imanager\Storage\ItemRepository::class),
-        );
+        $this->pages = $container->get(PageRepository::class);
         $this->cache = $container->get(FilesystemCache::class);
         $this->files = $container->get(FileRepository::class);
         $this->fileStorage = $container->get(FileStorage::class);
@@ -116,48 +117,43 @@ class Site
     }
 
     /**
-     * Resolve the requested page from the URL or fall back to home/404.
+     * Resolve the requested page from the URL or fall back to 404.
      *
-     * The lookup honours nested page paths: when multiple pages share the
-     * same slug the parent chain is verified by walking back through the
-     * URL segments and rejecting mismatches as 404.
+     * The actual resolution lives in plugins now. Built-in DB-backed
+     * slug resolution is shipped as `DbPagesResolverPlugin` (registered
+     * as a core plugin in boot.php). This method only orchestrates the
+     * event dispatch:
+     *
+     * 1. Dispatch {@see PageResolving}. Listeners can fill the
+     *    `resolution` slot; first writer wins by convention.
+     * 2. If something resolved, dispatch {@see PageResolved} for
+     *    read-only side-effect listeners and return.
+     * 3. Otherwise dispatch {@see RouteNotFound} as a last-chance
+     *    resolver. If it still produces nothing, throw the 404.
      */
     public function execute(): void
     {
-        if ($this->urlSegments->isEmpty()) {
-            $this->page = $this->pages->findHome();
-            if ($this->page === null || ! $this->page->active()) {
-                $this->throw404();
-            }
+        $dispatcher = $this->container->get(EventDispatcherInterface::class);
+
+        $resolving = new PageResolving($this->urlSegments);
+        $dispatcher->dispatch($resolving);
+
+        if ($resolving->resolution !== null) {
+            $this->page = $resolving->resolution;
+            $dispatcher->dispatch(new PageResolved($this->page));
             return;
         }
 
-        $slug = $this->urlSegments->last();
-        if ($slug === null) {
-            $this->page = $this->pages->findHome();
+        $notFound = new RouteNotFound($this->urlSegments);
+        $dispatcher->dispatch($notFound);
+
+        if ($notFound->resolution !== null) {
+            $this->page = $notFound->resolution;
+            $dispatcher->dispatch(new PageResolved($this->page));
             return;
         }
 
-        $page = $this->pages->findBySlug($this->sanitizer->slug($slug));
-        if ($page === null || ! $page->active()) {
-            $this->throw404();
-            return;
-        }
-
-        // Confirm the URL fully matches the page's parent chain so a
-        // request like /wrong-parent/articles/ does not silently render
-        // the matching child page. The home page (id=1) is reachable
-        // both via `/` (already handled above) and via its own slug.
-        if ($page->id() !== 1) {
-            $expected = '/' . $this->getPageUrl($page);
-            $actual   = '/' . $this->urlSegments->path(trailingSlash: true);
-            if ($actual !== $expected) {
-                $this->throw404();
-                return;
-            }
-        }
-
-        $this->page = $page;
+        $this->throw404();
     }
 
     public function render(string $element): ?string

--- a/boot/Plugin/CorePlugins/DbPagesResolverPlugin.php
+++ b/boot/Plugin/CorePlugins/DbPagesResolverPlugin.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Plugin\CorePlugins;
+
+use Imanager\Http\UrlSegments;
+use Imanager\Validation\Sanitizer as ImanagerSanitizer;
+use Scriptor\Boot\Events\Frontend\PageResolving;
+use Scriptor\Boot\Frontend\Page;
+use Scriptor\Boot\Frontend\PageRepository;
+use Scriptor\Boot\Plugin\Plugin;
+use Scriptor\Boot\Plugin\PluginContext;
+
+/**
+ * Built-in resolver that maps URL segments to a {@see Page} via the
+ * iManager-backed slug table. Before the Plugin API existed, this
+ * logic sat inline in {@see Scriptor\Boot\Frontend\Site::execute()};
+ * extracting it into a plugin makes the dispatch pipeline uniform:
+ * core resolution and third-party resolution travel the same path.
+ *
+ * Resolution rules (preserved verbatim from the old Site::execute):
+ *
+ * - Empty URL falls back to the home page (id 1).
+ * - Otherwise the last segment is sanitised to a slug and looked up.
+ * - The home page is reachable both via the empty URL and via its
+ *   own slug; everything else must match its full parent chain or
+ *   the resolution is rejected (the request will fall through to
+ *   {@see Site::throw404()}).
+ * - Inactive pages do not resolve.
+ *
+ * The plugin self-checks the resolution slot at the start of its
+ * handler: if any earlier listener already filled it, this plugin
+ * does nothing. That is the "first writer wins" convention every
+ * PageResolving listener follows.
+ */
+final class DbPagesResolverPlugin implements Plugin
+{
+    public function name(): string
+    {
+        return 'core/db-pages-resolver';
+    }
+
+    public function version(): string
+    {
+        return '1.0.0';
+    }
+
+    public function register(PluginContext $context): void
+    {
+        $container = $context->container();
+        $context->subscribe(
+            PageResolving::class,
+            static function (PageResolving $event) use ($container): void {
+                if ($event->resolution !== null) {
+                    return;
+                }
+                $pages     = $container->get(PageRepository::class);
+                $sanitizer = $container->get(ImanagerSanitizer::class);
+                $resolved  = self::resolve($event->urlSegments, $pages, $sanitizer);
+                if ($resolved !== null) {
+                    $event->resolution = $resolved;
+                }
+            },
+        );
+    }
+
+    private static function resolve(
+        UrlSegments $segments,
+        PageRepository $pages,
+        ImanagerSanitizer $sanitizer,
+    ): ?Page {
+        if ($segments->isEmpty()) {
+            $home = $pages->findHome();
+            return ($home !== null && $home->active()) ? $home : null;
+        }
+
+        $last = $segments->last();
+        if ($last === null) {
+            $home = $pages->findHome();
+            return ($home !== null && $home->active()) ? $home : null;
+        }
+
+        $slug = $sanitizer->slug($last);
+        $page = $pages->findBySlug($slug);
+        if ($page === null || ! $page->active()) {
+            return null;
+        }
+
+        // Home (id 1) is reachable via both `/` and its own slug.
+        // Every other page must match its parent chain so a request
+        // like `/wrong-parent/articles/` does not silently render
+        // the matching child page elsewhere in the tree.
+        if ($page->id() !== 1) {
+            $expected = self::buildPageUrl($page, $pages);
+            $actual   = $segments->path(trailingSlash: true);
+            if ($actual !== $expected) {
+                return null;
+            }
+        }
+
+        return $page;
+    }
+
+    /**
+     * @param array<int, true> $visited
+     */
+    private static function buildPageUrl(Page $page, PageRepository $pages, array $visited = []): string
+    {
+        $id = $page->id() ?? 0;
+        if (isset($visited[$id])) {
+            return $page->slug !== '' ? $page->slug . '/' : '';
+        }
+        $visited[$id] = true;
+
+        $url = '';
+        if ($page->parent !== 0 && $page->parent !== $id) {
+            $parent = $pages->find($page->parent);
+            if ($parent !== null) {
+                $url .= self::buildPageUrl($parent, $pages, $visited);
+            }
+        }
+        if ($id !== 1) {
+            $url .= $page->slug . '/';
+        }
+        return $url;
+    }
+}

--- a/boot/Plugin/PluginContext.php
+++ b/boot/Plugin/PluginContext.php
@@ -4,17 +4,20 @@ declare(strict_types=1);
 
 namespace Scriptor\Boot\Plugin;
 
+use Imanager\Events\SubscriberListenerProvider;
 use League\Container\Container;
 
 /**
  * Registration surface handed to every plugin's {@see Plugin::register()}.
  *
- * Phase 2 exposes only the DI container. Plugins can bind services
- * (`$context->container()->add(MyService::class)`) and resolve
- * framework services they need. Subsequent phases extend this surface:
+ * Phase 2 exposed the DI container. Phase 3 adds event subscriptions
+ * (PSR-14) via {@see subscribe()}; the underlying listener provider is
+ * the same one iManager wires for its storage events, so a plugin can
+ * subscribe to Scriptor frontend events and iManager storage events
+ * with the same call.
  *
- * - Phase 3 adds `subscribe(string $event, callable $handler)` for
- *   PSR-14 frontend event subscriptions.
+ * Subsequent phases extend this surface:
+ *
  * - Phase 4 adds `registerEditorModule()` and `addEditorMenuItem()`
  *   for editor extension hooks.
  *
@@ -30,5 +33,23 @@ final class PluginContext
     public function container(): Container
     {
         return $this->container;
+    }
+
+    /**
+     * Subscribe to an event by class name. The handler runs for every
+     * dispatched event that is an instance of `$eventClass` (or a
+     * subclass), in registration order.
+     *
+     * `$handler` should declare its concrete event class in its
+     * signature; PHP type-checks at call time. The plain `callable`
+     * type here keeps PHPStan happy under callable-variance.
+     *
+     * @param class-string $eventClass
+     */
+    public function subscribe(string $eventClass, callable $handler): void
+    {
+        /** @var SubscriberListenerProvider $provider */
+        $provider = $this->container->get(SubscriberListenerProvider::class);
+        $provider->subscribe($eventClass, $handler);
     }
 }

--- a/boot/Plugin/PluginManager.php
+++ b/boot/Plugin/PluginManager.php
@@ -37,13 +37,19 @@ final class PluginManager
     private array $bootedPlugins = [];
 
     /**
-     * @param list<string> $disabled FQCNs of plugins to skip at boot.
+     * @param list<string> $disabled    FQCNs of plugins to skip at boot.
+     * @param list<string> $corePlugins FQCNs of first-party plugins shipped
+     *                                  inside Scriptor itself (not via Composer).
+     *                                  They boot before discovered plugins, so
+     *                                  user plugins can override any service or
+     *                                  listener a core plugin registered.
      */
     public function __construct(
         private readonly Container $container,
         private readonly string $vendorDir,
         private readonly string $cachePath,
         private readonly array $disabled = [],
+        private readonly array $corePlugins = [],
     ) {}
 
     /**
@@ -74,9 +80,9 @@ final class PluginManager
     }
 
     /**
-     * Instantiate every discovered plugin (skipping disabled ones),
-     * call {@see Plugin::register()}. Idempotent: subsequent calls
-     * within the same request are a no-op.
+     * Instantiate every plugin (core first, then discovered, skipping
+     * disabled ones in both sets), call {@see Plugin::register()}.
+     * Idempotent: subsequent calls within the same request are a no-op.
      */
     public function bootAll(): void
     {
@@ -84,20 +90,29 @@ final class PluginManager
             return;
         }
         $context = new PluginContext($this->container);
-        foreach ($this->discover() as $manifest) {
-            if (in_array($manifest->pluginClass, $this->disabled, true)) {
-                continue;
-            }
-            if (! class_exists($manifest->pluginClass)) {
-                continue;
-            }
-            $instance = new $manifest->pluginClass();
-            if (! $instance instanceof Plugin) {
-                continue;
-            }
-            $instance->register($context);
-            $this->bootedPlugins[] = $instance;
+
+        foreach ($this->corePlugins as $class) {
+            $this->bootPluginClass($class, $context);
         }
+        foreach ($this->discover() as $manifest) {
+            $this->bootPluginClass($manifest->pluginClass, $context);
+        }
+    }
+
+    private function bootPluginClass(string $class, PluginContext $context): void
+    {
+        if (in_array($class, $this->disabled, true)) {
+            return;
+        }
+        if (! class_exists($class)) {
+            return;
+        }
+        $instance = new $class();
+        if (! $instance instanceof Plugin) {
+            return;
+        }
+        $instance->register($context);
+        $this->bootedPlugins[] = $instance;
     }
 
     /** @return list<Plugin> */


### PR DESCRIPTION
Wires the request-pipeline dispatch surface promised in Phase 1's plan (docs/scriptor-plugin-api-plan.md, sections 3.3 and 3.5). Phase 3 ships three of the planned five events; ContentRendering and Rendered land later when a plugin actually needs them.

What lands:

- boot/Events/Frontend/PageResolving.php Dispatched at the start of Site::execute(). Carries the URL segments and a mutable Page-resolution slot. First listener to set a non-null resolution wins; subsequent listeners self-check. PSR-14 convention.

- boot/Events/Frontend/PageResolved.php Read-only event fired after a resolution wins. For listeners that want to observe (logging, ACL throws, breadcrumbs) without influencing the outcome.

- boot/Events/Frontend/RouteNotFound.php Last-chance event before throw404 actually renders. Same mutable slot as PageResolving; lets plugins answer only the patterns they care about without claiming resolution authority upfront.

- boot/Plugin/PluginContext.php New subscribe(eventClass, handler) method that adds listeners to iManager's SubscriberListenerProvider (already in the container). Same listener provider iManager uses for storage events, so a plugin can subscribe to both Scriptor and iManager events with one call.

- boot/Plugin/PluginManager.php New corePlugins constructor parameter for first-party plugins that live inside Scriptor itself (not via Composer discovery). They boot before discovered plugins, so user plugins can override anything a core plugin registered. Plus a small bootPluginClass() extraction shared by both code paths.

- boot/Plugin/CorePlugins/DbPagesResolverPlugin.php First first-party plugin. Subscribes to PageResolving and runs the built-in slug-table resolution (with the same parent-chain rules the old Site::execute had). Operators can disable it via $config['plugins']['disabled'] for a headless site whose only resolver is a different plugin.

- boot/Frontend/Site.php execute() now only dispatches events. The slug lookup is gone from this file; the plugin is the only path. Same external behavior (empty URL goes to home, unknown slugs land in throw404, parent chain is verified), just orchestrated through PSR-14.

- boot.php Binds Scriptor\Boot\Frontend\PageRepository as a shared container service (discovery-loop output: it was constructed inline by Site before; plugins could not reach it without rebinding it themselves). Registers DbPagesResolverPlugin in the new corePlugins list.

Smoke (CLI, against host data/imanager.db):

  $ php -r 'require "boot.php"; ...' → Booted plugins: 1
  →   - core/db-pages-resolver v1.0.0
  → Empty URL resolved to: Scriptor's Demo Page  (via PageResolving listener)
  → /nonexistent/ resolved to: NULL              (handler falls through correctly)

The InfoTheme still pre-empts markdown URLs inside its own execute() override before parent::execute runs, so the markdown-document route on scriptor-cms.dev keeps working unchanged. The full plug-in path will replace that override in Phase 5 (the scriptor-markdown-pages plugin extract).

Plan reference: docs/scriptor-plugin-api-plan.md, sections 3.3, 3.5, 3.7 (first-party plugins as showcase).