### PR TITLE
feat(plugin): editor extension hooks via ModuleRegistry + MenuRegistr…

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use Scriptor\Boot\App;
+use Scriptor\Boot\Editor\Menu\MenuRegistry;
+use Scriptor\Boot\Editor\ModuleRegistry;
 use Scriptor\Boot\ImanagerBootstrap;
 use Scriptor\Boot\Plugin\PluginManager;
 
@@ -22,6 +24,13 @@ App::container()->addShared(
             App::container()->get(\Imanager\Storage\ItemRepository::class),
         ),
 );
+
+// Editor extension registries. Created empty here so the CoreEditorPlugin
+// and any third-party plugin can populate them during Plugin::register().
+// EditorRouter reads ModuleRegistry to dispatch; the editor layout
+// templates read MenuRegistry to render the sidebar and profile cluster.
+App::container()->addShared(ModuleRegistry::class, static fn() => new ModuleRegistry());
+App::container()->addShared(MenuRegistry::class,   static fn() => new MenuRegistry());
 
 /*
  * Boot path:
@@ -49,18 +58,25 @@ if (file_exists(__DIR__ . '/data/settings/custom.scriptor-config.php')) {
     );
 }
 
+// Make the resolved config and the Scriptor root reachable via the
+// container so plugins can read them at register() time, before
+// per-request services like Editor or Site exist.
+App::container()->add('scriptor.config', $config);
+App::container()->add('scriptor.root',   __DIR__);
+
 $pluginManager = new PluginManager(
     container:   App::container(),
     vendorDir:   __DIR__ . '/vendor',
     cachePath:   __DIR__ . '/data/cache/plugins.php',
     disabled:    (array) ($config['plugins']['disabled'] ?? []),
     corePlugins: [
-        // Built-in DB slug resolver. Sits behind the same PageResolving
-        // event that third-party plugins subscribe to so the dispatch
-        // pipeline is uniform. Operators can disable this by adding the
-        // FQCN to $config['plugins']['disabled'] (for a headless site
-        // that only resolves pages through a custom resolver plugin).
+        // Built-in DB slug resolver. Subscribes to PageResolving and
+        // runs the same DB-backed lookup the old Site::execute had.
         \Scriptor\Boot\Plugin\CorePlugins\DbPagesResolverPlugin::class,
+
+        // Built-in editor surfaces (pages, profile, auth, settings,
+        // install). Seeds ModuleRegistry + MenuRegistry from config.
+        \Scriptor\Boot\Plugin\CorePlugins\CoreEditorPlugin::class,
     ],
 );
 $pluginManager->bootAll();

--- a/boot/Editor/Auth/AuthModule.php
+++ b/boot/Editor/Auth/AuthModule.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Scriptor\Boot\Editor\Auth;
 
 use Scriptor\Boot\Editor\Editor;
+use Scriptor\Boot\Editor\Module;
 use Scriptor\Boot\Editor\UserRepository;
 
 /**
@@ -19,7 +20,7 @@ use Scriptor\Boot\Editor\UserRepository;
  * bcrypt hash that the migrator preserved in the user item's `password`
  * field (Phase 9 + iManager `PasswordFieldType`).
  */
-final class AuthModule
+final class AuthModule implements Module
 {
     public function __construct(
         private readonly Editor $editor,

--- a/boot/Editor/EditorRouter.php
+++ b/boot/Editor/EditorRouter.php
@@ -6,38 +6,30 @@ namespace Scriptor\Boot\Editor;
 
 use Imanager\Files\FileStorage;
 use Imanager\Files\ImageProcessor;
-use Imanager\Storage\CategoryRepository;
-use Imanager\Storage\FieldRepository;
 use Imanager\Storage\FileRepository;
-use Imanager\Storage\ItemRepository;
 use Imanager\Validation\Sanitizer as ImanagerSanitizer;
 use League\Container\Container;
 use Scriptor\Boot\Editor\Api\UploadEndpoint;
-use Scriptor\Boot\Editor\Auth\AuthModule;
-use Scriptor\Boot\Editor\Auth\LoginAttempts;
-use Scriptor\Boot\Editor\Install\InstallModule;
-use Scriptor\Boot\Editor\Pages\PagesModule;
-use Scriptor\Boot\Editor\Profile\ProfileModule;
-use Scriptor\Boot\Editor\Settings\SettingsModule;
-use Scriptor\Boot\Frontend\PageRepository;
 
 /**
- * Editor URL router — dispatches to the right module.
+ * Editor URL router. The first segment selects which module handles
+ * the request. Modules live behind {@see ModuleRegistry}: both first-
+ * party surfaces (auth, pages, profile, settings, install) and
+ * plugin-contributed ones are registered the same way, so this
+ * dispatcher has one code path instead of an if-ladder.
  *
- * Modules:
- *   - auth      login / logout (CSRF + bcrypt password verification)
- *   - pages     page list + edit (FilePond uploads, Markdown preview)
- *   - profile   logged-in user edits their own record
- *   - settings  read-only "edit data/settings/*.php manually" page
- *   - install   discover / install / uninstall site/modules/* plugins
- *   - api       JSON endpoints (/editor/api/upload — POST/PATCH/DELETE)
+ * Auth gating is still hard-coded here because it crosses every
+ * module rather than living inside one. The flow is:
  *
- * Auth gating:
- *   - `auth/*` is always reachable (anonymous login form);
- *   - `api/*` returns 401 JSON for anonymous callers;
- *   - everything else 302's to `/editor/auth/` until logged in.
+ *   /auth(/...)       always reachable (the login form needs to be)
+ *   /api/...          401 JSON when not logged in; auth otherwise
+ *   /<anything-else>  302 to /auth/ until logged in
  *
- * Unknown module slugs return a 404 page through {@see renderUnknownModule()}.
+ * Once auth has passed, the dispatcher looks up the first URL segment
+ * in the registry and instantiates the module via its factory. The
+ * factory receives the DI container plus this request's Editor, which
+ * is enough to resolve every per-request dependency (the same closures
+ * that used to live in dispatch*() helpers below).
  */
 final class EditorRouter
 {
@@ -51,13 +43,11 @@ final class EditorRouter
         $first = $this->editor->urlSegments->first();
 
         if ($first === 'auth' || ($first === null && ! $this->editor->isLoggedIn())) {
-            $this->dispatchAuth();
+            $this->dispatchModule('auth');
             return;
         }
 
         if (! $this->editor->isLoggedIn()) {
-            // JSON endpoints get a 401 instead of a 302 so XHR callers
-            // (FilePond, future SPA bits) can react to it cleanly.
             if ($first === 'api') {
                 $this->jsonError(401, 'Authentication required');
             }
@@ -74,55 +64,32 @@ final class EditorRouter
             return;
         }
 
-        if ($first === 'pages') {
-            $this->dispatchPages();
+        if (! $this->moduleRegistry()->has($first)) {
+            $this->renderUnknownModule($first);
             return;
         }
 
-        if ($first === 'profile') {
-            $this->dispatchProfile();
-            return;
-        }
-
-        if ($first === 'settings') {
-            (new SettingsModule($this->editor))->execute();
-            return;
-        }
-
-        if ($first === 'install') {
-            (new InstallModule($this->editor, dirname(__DIR__, 2)))->execute();
-            return;
-        }
-
-        $this->renderUnknownModule($first);
+        $this->dispatchModule($first);
     }
 
-    private function dispatchPages(): void
+    private function dispatchModule(string $slug): void
     {
-        $module = new PagesModule(
-            $this->editor,
-            new PageRepository(
-                $this->container->get(CategoryRepository::class),
-                $this->container->get(ItemRepository::class),
-            ),
-            $this->container->get(FieldRepository::class),
-            $this->container->get(FileRepository::class),
-        );
+        $module = $this->moduleRegistry()->create($slug, $this->container, $this->editor);
         $module->execute();
     }
 
-    private function dispatchProfile(): void
+    private function moduleRegistry(): ModuleRegistry
     {
-        $module = new ProfileModule(
-            $this->editor,
-            new UserRepository(
-                $this->container->get(CategoryRepository::class),
-                $this->container->get(ItemRepository::class),
-            ),
-        );
-        $module->execute();
+        /** @var ModuleRegistry $registry */
+        $registry = $this->container->get(ModuleRegistry::class);
+        return $registry;
     }
 
+    /**
+     * JSON sub-tree under /editor/api/*. The only endpoint today is
+     * upload; adding more would justify an ApiEndpointRegistry, but
+     * for one entry inline dispatch is clearer than over-design.
+     */
     private function dispatchApi(): void
     {
         $resource = $this->editor->urlSegments->get(1);
@@ -145,23 +112,6 @@ final class EditorRouter
         header('Content-Type: application/json; charset=utf-8');
         echo json_encode(['error' => $message]);
         exit;
-    }
-
-    private function dispatchAuth(): void
-    {
-        $auth = new AuthModule(
-            $this->editor,
-            new UserRepository(
-                $this->container->get(CategoryRepository::class),
-                $this->container->get(ItemRepository::class),
-            ),
-            new LoginAttempts(
-                $this->editor->session,
-                maxAttempts: (int) ($this->editor->config['maxFailedAccessAttempts'] ?? 5),
-                lockoutMinutes: (int) ($this->editor->config['accessLockoutDuration'] ?? 5),
-            ),
-        );
-        $auth->execute();
     }
 
     private function renderDashboard(): void

--- a/boot/Editor/Install/InstallModule.php
+++ b/boot/Editor/Install/InstallModule.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Scriptor\Boot\Editor\Install;
 
 use Scriptor\Boot\Editor\Editor;
+use Scriptor\Boot\Editor\Module;
 
 /**
  * Install module — list site/modules/* candidates, install/uninstall
@@ -26,7 +27,7 @@ use Scriptor\Boot\Editor\Editor;
  * expose `public static function moduleInfo(): array`. Modules that
  * don't are skipped silently.
  */
-final class InstallModule
+final class InstallModule implements Module
 {
     private const DEFAULT_CUSTOM_CONFIG = [
         'modules' => [],

--- a/boot/Editor/Menu/MenuItem.php
+++ b/boot/Editor/Menu/MenuItem.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Editor\Menu;
+
+/**
+ * One menu entry in the editor chrome.
+ *
+ * `displayType` is the layout slot that renders the entry. The two
+ * built-in slots are `sidebar` (left-rail navigation in
+ * `editor/theme/summary.php`) and `profile` (top-right cluster in
+ * `editor/theme/header.php`). A plugin can introduce its own slot by
+ * adding a template fragment that reads the same registry with a new
+ * displayType string.
+ *
+ * `href` is optional. When null the layout derives it from the slug
+ * (`<siteUrl>/<slug>/`). Pass a literal href for entries that need a
+ * suffix, e.g. logout with a CSRF query string.
+ */
+final readonly class MenuItem
+{
+    public function __construct(
+        public string $slug,
+        public string $label,
+        public string $icon = '',
+        public string $displayType = 'sidebar',
+        public int $position = 0,
+        public ?string $href = null,
+    ) {}
+}

--- a/boot/Editor/Menu/MenuRegistry.php
+++ b/boot/Editor/Menu/MenuRegistry.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Editor\Menu;
+
+/**
+ * Holds the editor's menu entries and filters them by display slot.
+ *
+ * Both `summary.php` (sidebar) and `header.php` (profile cluster) read
+ * from this registry. The legacy `$config['modules']` driven menus are
+ * preserved by {@see Scriptor\Boot\Plugin\CorePlugins\CoreEditorPlugin}
+ * which seeds this registry from the config at boot. Plugins add
+ * entries via {@see Scriptor\Boot\Plugin\PluginContext::addEditorMenuItem()}.
+ */
+final class MenuRegistry
+{
+    /** @var list<MenuItem> */
+    private array $items = [];
+
+    public function add(MenuItem $item): void
+    {
+        $this->items[] = $item;
+    }
+
+    /**
+     * Items registered for the given display slot, sorted by ascending
+     * position then by registration order.
+     *
+     * @return list<MenuItem>
+     */
+    public function forDisplay(string $displayType): array
+    {
+        $matching = [];
+        foreach ($this->items as $index => $item) {
+            if ($item->displayType === $displayType) {
+                $matching[] = [$index, $item];
+            }
+        }
+        usort($matching, static function (array $a, array $b): int {
+            $cmp = $a[1]->position <=> $b[1]->position;
+            return $cmp !== 0 ? $cmp : ($a[0] <=> $b[0]);
+        });
+        return array_map(static fn (array $pair): MenuItem => $pair[1], $matching);
+    }
+}

--- a/boot/Editor/Module.php
+++ b/boot/Editor/Module.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Editor;
+
+/**
+ * Contract every editor module satisfies.
+ *
+ * A module owns a top-level URL slug under `/editor/<slug>/...` and
+ * runs from the {@see EditorRouter} once the auth gate (if any) has
+ * passed. The router resolves the slug to a factory via
+ * {@see ModuleRegistry}, instantiates the module per request, and
+ * calls {@see execute()}.
+ *
+ * Render output lands on `$editor->pageContent`; the module never
+ * echoes directly so the layout template (`editor/theme/template.php`)
+ * stays in charge of head/header/footer/messages.
+ */
+interface Module
+{
+    public function execute(): void;
+}

--- a/boot/Editor/ModuleRegistry.php
+++ b/boot/Editor/ModuleRegistry.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Editor;
+
+use League\Container\Container;
+
+/**
+ * Slug-to-factory lookup for editor modules.
+ *
+ * The {@see EditorRouter} reads from this registry to resolve which
+ * module handles a given URL. Both first-party modules
+ * (shipped by {@see Scriptor\Boot\Plugin\CorePlugins\CoreEditorPlugin})
+ * and plugin-contributed modules go through the same entry, so the
+ * router has one code path instead of an if-ladder.
+ *
+ * Factories receive the DI container plus the per-request
+ * {@see Editor} instance. The latter is not in the container because
+ * Editor is constructed in editor/index.php after session boot, which
+ * is later than plugin {@see Plugin::register()} runs; passing it as a
+ * positional argument keeps factory closures self-contained.
+ */
+final class ModuleRegistry
+{
+    /** @var array<string, callable(Container, Editor): Module> */
+    private array $factories = [];
+
+    /**
+     * Override semantics: re-registering an existing slug replaces the
+     * previous factory. Plugins boot in registration order
+     * (core first, then discovered), so a third-party plugin can take
+     * over an editor route from a core module if it really needs to.
+     *
+     * @param callable(Container, Editor): Module $factory
+     */
+    public function register(string $slug, callable $factory): void
+    {
+        $this->factories[$slug] = $factory;
+    }
+
+    public function has(string $slug): bool
+    {
+        return isset($this->factories[$slug]);
+    }
+
+    public function create(string $slug, Container $container, Editor $editor): Module
+    {
+        if (! isset($this->factories[$slug])) {
+            throw new \RuntimeException("Unknown editor module slug: {$slug}");
+        }
+        return ($this->factories[$slug])($container, $editor);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function slugs(): array
+    {
+        return array_keys($this->factories);
+    }
+}

--- a/boot/Editor/Pages/PagesModule.php
+++ b/boot/Editor/Pages/PagesModule.php
@@ -9,6 +9,7 @@ use Imanager\Domain\Item;
 use Imanager\Storage\FieldRepository;
 use Imanager\Storage\FileRepository;
 use Scriptor\Boot\Editor\Editor;
+use Scriptor\Boot\Editor\Module;
 use Scriptor\Boot\Frontend\Page;
 use Scriptor\Boot\Frontend\PageRepository;
 
@@ -27,7 +28,7 @@ use Scriptor\Boot\Frontend\PageRepository;
  * the action handlers; render output lands on `$editor->pageContent`
  * exactly like the auth module.
  */
-final class PagesModule
+final class PagesModule implements Module
 {
     /** @var list<int> */
     private array $reservedSlugs;

--- a/boot/Editor/Profile/ProfileModule.php
+++ b/boot/Editor/Profile/ProfileModule.php
@@ -6,6 +6,7 @@ namespace Scriptor\Boot\Editor\Profile;
 
 use Imanager\Domain\Item;
 use Scriptor\Boot\Editor\Editor;
+use Scriptor\Boot\Editor\Module;
 use Scriptor\Boot\Editor\UserRepository;
 
 /**
@@ -22,7 +23,7 @@ use Scriptor\Boot\Editor\UserRepository;
  * change written here stays compatible with rows that have already
  * been re-saved as plain hashes alongside ones that haven't.
  */
-final class ProfileModule
+final class ProfileModule implements Module
 {
     private const MIN_PASSWORD_LENGTH = 6;
 

--- a/boot/Editor/Settings/SettingsModule.php
+++ b/boot/Editor/Settings/SettingsModule.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Scriptor\Boot\Editor\Settings;
 
 use Scriptor\Boot\Editor\Editor;
+use Scriptor\Boot\Editor\Module;
 
 /**
  * Settings module — informational page that points the admin at the
@@ -15,7 +16,7 @@ use Scriptor\Boot\Editor\Editor;
  * A future iManager 2.0 settings UI (post-Phase-17) would replace
  * this with an in-place editor; for Phase 14 we keep parity.
  */
-final class SettingsModule
+final class SettingsModule implements Module
 {
     public function __construct(private readonly Editor $editor) {}
 

--- a/boot/Plugin/CorePlugins/CoreEditorPlugin.php
+++ b/boot/Plugin/CorePlugins/CoreEditorPlugin.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Plugin\CorePlugins;
+
+use Imanager\Storage\CategoryRepository;
+use Imanager\Storage\FieldRepository;
+use Imanager\Storage\FileRepository;
+use Imanager\Storage\ItemRepository;
+use League\Container\Container;
+use Scriptor\Boot\Editor\Auth\AuthModule;
+use Scriptor\Boot\Editor\Auth\LoginAttempts;
+use Scriptor\Boot\Editor\Editor;
+use Scriptor\Boot\Editor\Install\InstallModule;
+use Scriptor\Boot\Editor\Menu\MenuItem;
+use Scriptor\Boot\Editor\Module;
+use Scriptor\Boot\Editor\Pages\PagesModule;
+use Scriptor\Boot\Editor\Profile\ProfileModule;
+use Scriptor\Boot\Editor\Settings\SettingsModule;
+use Scriptor\Boot\Editor\UserRepository;
+use Scriptor\Boot\Frontend\PageRepository;
+use Scriptor\Boot\Plugin\Plugin;
+use Scriptor\Boot\Plugin\PluginContext;
+
+/**
+ * Registers the five built-in editor modules through the same
+ * {@see ModuleRegistry} / {@see MenuRegistry} surface that third-party
+ * plugins use. The {@see EditorRouter} no longer if-ladders over hard-
+ * coded slugs; it walks the registry instead.
+ *
+ * Menu items mirror what `data/settings/scriptor-config.php` (`modules`
+ * key) used to drive directly from `summary.php` / `header.php`. The
+ * config is still the source of truth for label / icon / position /
+ * display_type, so operators who have customised the menu in their own
+ * config keep their changes. Plugins additionally call
+ * `$context->addEditorMenuItem(...)` to extend.
+ */
+final class CoreEditorPlugin implements Plugin
+{
+    public function name(): string
+    {
+        return 'core/editor';
+    }
+
+    public function version(): string
+    {
+        return '1.0.0';
+    }
+
+    public function register(PluginContext $context): void
+    {
+        // Module factories. Each closure resolves its own dependencies
+        // from the container; Editor is passed positionally because it
+        // is constructed in editor/index.php after the plugin manager
+        // has already booted.
+
+        $context->registerEditorModule('pages', static fn (Container $c, Editor $e): Module
+            => new PagesModule(
+                $e,
+                $c->get(PageRepository::class),
+                $c->get(FieldRepository::class),
+                $c->get(FileRepository::class),
+            ));
+
+        $context->registerEditorModule('profile', static fn (Container $c, Editor $e): Module
+            => new ProfileModule(
+                $e,
+                new UserRepository(
+                    $c->get(CategoryRepository::class),
+                    $c->get(ItemRepository::class),
+                ),
+            ));
+
+        $context->registerEditorModule('auth', static fn (Container $c, Editor $e): Module
+            => new AuthModule(
+                $e,
+                new UserRepository(
+                    $c->get(CategoryRepository::class),
+                    $c->get(ItemRepository::class),
+                ),
+                new LoginAttempts(
+                    $e->session,
+                    maxAttempts: (int) ($e->config['maxFailedAccessAttempts'] ?? 5),
+                    lockoutMinutes: (int) ($e->config['accessLockoutDuration'] ?? 5),
+                ),
+            ));
+
+        $context->registerEditorModule('settings', static fn (Container $c, Editor $e): Module
+            => new SettingsModule($e));
+
+        $context->registerEditorModule('install', static fn (Container $c, Editor $e): Module
+            => new InstallModule($e, (string) $c->get('scriptor.root')));
+
+        // The api/upload endpoint is not a Module (it's a JSON
+        // endpoint, not a layout-bearing page), so it does NOT
+        // register here. EditorRouter keeps the api/* dispatch
+        // inline. If a future plugin contributes more api endpoints,
+        // we extract an ApiEndpointRegistry then.
+
+        // Seed the menu registry from the config['modules'] entries.
+        // This preserves the existing menu-driven layout exactly: any
+        // operator who tuned position/icon/menu/display_type in their
+        // own config sees the same chrome as before.
+        $config  = $context->container()->get('scriptor.config');
+        $modules = (array) ($config['modules'] ?? []);
+        foreach ($modules as $slug => $entry) {
+            if (! is_array($entry) || empty($entry['active'])) {
+                continue;
+            }
+            $displayTypes = (array) ($entry['display_type'] ?? []);
+            $menuKey      = (string) ($entry['menu'] ?? '');
+            $icon         = (string) ($entry['icon'] ?? '');
+            $position     = (int) ($entry['position'] ?? 0);
+
+            foreach ($displayTypes as $displayType) {
+                if (! is_string($displayType) || $displayType === '') {
+                    continue;
+                }
+                $context->addEditorMenuItem(new MenuItem(
+                    slug:        (string) $slug,
+                    label:       $menuKey,
+                    icon:        $icon,
+                    displayType: $displayType,
+                    position:    $position,
+                ));
+            }
+        }
+
+    }
+}

--- a/boot/Plugin/PluginContext.php
+++ b/boot/Plugin/PluginContext.php
@@ -6,20 +6,20 @@ namespace Scriptor\Boot\Plugin;
 
 use Imanager\Events\SubscriberListenerProvider;
 use League\Container\Container;
+use Scriptor\Boot\Editor\Editor;
+use Scriptor\Boot\Editor\Menu\MenuItem;
+use Scriptor\Boot\Editor\Menu\MenuRegistry;
+use Scriptor\Boot\Editor\Module;
+use Scriptor\Boot\Editor\ModuleRegistry;
 
 /**
  * Registration surface handed to every plugin's {@see Plugin::register()}.
  *
- * Phase 2 exposed the DI container. Phase 3 adds event subscriptions
- * (PSR-14) via {@see subscribe()}; the underlying listener provider is
- * the same one iManager wires for its storage events, so a plugin can
- * subscribe to Scriptor frontend events and iManager storage events
- * with the same call.
- *
- * Subsequent phases extend this surface:
- *
- * - Phase 4 adds `registerEditorModule()` and `addEditorMenuItem()`
- *   for editor extension hooks.
+ * Phase 2 exposed the DI container.
+ * Phase 3 added {@see subscribe()} for PSR-14 frontend events.
+ * Phase 4 adds {@see registerEditorModule()} and
+ * {@see addEditorMenuItem()} so plugins can plug their own surfaces
+ * into the editor.
  *
  * The context mediates every registration so the underlying wiring
  * can change without breaking plugins on every refactor.
@@ -40,10 +40,6 @@ final class PluginContext
      * dispatched event that is an instance of `$eventClass` (or a
      * subclass), in registration order.
      *
-     * `$handler` should declare its concrete event class in its
-     * signature; PHP type-checks at call time. The plain `callable`
-     * type here keeps PHPStan happy under callable-variance.
-     *
      * @param class-string $eventClass
      */
     public function subscribe(string $eventClass, callable $handler): void
@@ -51,5 +47,32 @@ final class PluginContext
         /** @var SubscriberListenerProvider $provider */
         $provider = $this->container->get(SubscriberListenerProvider::class);
         $provider->subscribe($eventClass, $handler);
+    }
+
+    /**
+     * Register an editor module under `/editor/<slug>/...`. The factory
+     * is called per request once the auth gate (if any) has passed.
+     * Override semantics: re-registering an existing slug replaces the
+     * previous factory.
+     *
+     * @param callable(Container, Editor): Module $factory
+     */
+    public function registerEditorModule(string $slug, callable $factory): void
+    {
+        /** @var ModuleRegistry $registry */
+        $registry = $this->container->get(ModuleRegistry::class);
+        $registry->register($slug, $factory);
+    }
+
+    /**
+     * Add an entry to the editor chrome (sidebar or profile cluster,
+     * depending on `$item->displayType`). Items render in ascending
+     * `position` order then by registration order.
+     */
+    public function addEditorMenuItem(MenuItem $item): void
+    {
+        /** @var MenuRegistry $registry */
+        $registry = $this->container->get(MenuRegistry::class);
+        $registry->add($item);
     }
 }

--- a/editor/theme/header.php
+++ b/editor/theme/header.php
@@ -14,21 +14,20 @@ if (! $editor->isLoggedIn()) {
 	<ul class="profile">
 <?php
 $activeSlug = $editor->urlSegments->first() ?? '';
-foreach ((array) ($editor->config['modules'] ?? []) as $slug => $module) {
-    if (
-        empty($module['active'])
-        || ! \is_array($module['display_type'] ?? null)
-        || ! \in_array('profile', $module['display_type'], true)
-    ) {
-        continue;
-    }
-    $isLogout = ($module['menu'] ?? '') === 'logout_menu';
-    $href = $editor->siteUrl . '/' . $slug . '/' . ($isLogout ? 'logout/' . $editor->csrfQueryString() : '');
-    $label = $editor->i18n[$module['menu']] ?? (string) $module['menu'];
-    $icon  = (string) ($module['icon'] ?? '');
-    $cls   = $activeSlug === $slug ? ' class="active"' : '';
+/** @var \Scriptor\Boot\Editor\Menu\MenuRegistry $menu */
+$menu = \Scriptor\Boot\App::container()->get(\Scriptor\Boot\Editor\Menu\MenuRegistry::class);
+foreach ($menu->forDisplay('profile') as $item) {
+    // Logout entry needs a CSRF query string in the URL. Anchored on
+    // the label key the CoreEditorPlugin seeds from the config rather
+    // than a flag on MenuItem, so plugin-contributed profile items
+    // don't accidentally trigger the logout suffix.
+    $isLogout = $item->slug === 'auth' && $item->label === 'logout_menu';
+    $href = $item->href
+        ?? $editor->siteUrl . '/' . $item->slug . '/' . ($isLogout ? 'logout/' . $editor->csrfQueryString() : '');
+    $label = $editor->i18n[$item->label] ?? $item->label;
+    $cls   = $activeSlug === $item->slug ? ' class="active"' : '';
 ?>
-		<li<?= $cls ?>><a href="<?= htmlspecialchars($href, ENT_QUOTES) ?>"><i class="<?= htmlspecialchars($icon, ENT_QUOTES) ?>"></i><span><?= htmlspecialchars($label, ENT_QUOTES) ?></span></a></li>
+		<li<?= $cls ?>><a href="<?= htmlspecialchars($href, ENT_QUOTES) ?>"><i class="<?= htmlspecialchars($item->icon, ENT_QUOTES) ?>"></i><span><?= htmlspecialchars($label, ENT_QUOTES) ?></span></a></li>
 <?php } ?>
 	</ul>
 </header>

--- a/editor/theme/summary.php
+++ b/editor/theme/summary.php
@@ -9,21 +9,15 @@
 		<ul class="summary">
 <?php
 $activeSlug = $editor->urlSegments->first() ?? '';
-foreach ((array) ($editor->config['modules'] ?? []) as $slug => $module) {
-    if (
-        empty($module['active'])
-        || ! \is_array($module['display_type'] ?? null)
-        || ! \in_array('sidebar', $module['display_type'], true)
-    ) {
-        continue;
-    }
-    $href  = $editor->siteUrl . '/' . $slug . '/';
-    $label = $editor->i18n[$module['menu']] ?? (string) $module['menu'];
-    $icon  = (string) ($module['icon'] ?? '');
-    $cls   = 'chapter' . ($activeSlug === $slug ? ' active' : '');
+/** @var \Scriptor\Boot\Editor\Menu\MenuRegistry $menu */
+$menu = \Scriptor\Boot\App::container()->get(\Scriptor\Boot\Editor\Menu\MenuRegistry::class);
+foreach ($menu->forDisplay('sidebar') as $item) {
+    $href  = $item->href ?? ($editor->siteUrl . '/' . $item->slug . '/');
+    $label = $editor->i18n[$item->label] ?? $item->label;
+    $cls   = 'chapter' . ($activeSlug === $item->slug ? ' active' : '');
 ?>
 			<li class="<?= htmlspecialchars($cls, ENT_QUOTES) ?>" data-level="1.1" data-path="./">
-				<a href="<?= htmlspecialchars($href, ENT_QUOTES) ?>"><?= $icon !== '' ? '<i class="' . htmlspecialchars($icon, ENT_QUOTES) . '"></i>' : '' ?><span><?= htmlspecialchars($label, ENT_QUOTES) ?></span></a>
+				<a href="<?= htmlspecialchars($href, ENT_QUOTES) ?>"><?= $item->icon !== '' ? '<i class="' . htmlspecialchars($item->icon, ENT_QUOTES) . '"></i>' : '' ?><span><?= htmlspecialchars($label, ENT_QUOTES) ?></span></a>
 			</li>
 <?php } ?>
 		</ul>


### PR DESCRIPTION
…y (Phase 4)

Closes the implementation half of the Phase 1 plan (docs/scriptor-plugin-api-plan.md, section 3.6). The EditorRouter's hard-coded if-ladder is gone; both first-party modules and plugin- contributed ones travel the same registry-based dispatch. The editor's sidebar and profile cluster now read from a MenuRegistry that the CoreEditorPlugin seeds from $config['modules'], preserving every operator customisation that used to drive the templates directly.

What lands:

- boot/Editor/Module.php Common contract every editor module satisfies (execute(): void). The five built-ins now declare `implements Module`.

- boot/Editor/ModuleRegistry.php Slug-to-factory map. Override semantics: re-registering a slug replaces. Factories receive both the DI container and the per- request Editor (Editor is constructed in editor/index.php after plugin boot, so it cannot be in the container at register() time; passing it positionally keeps factory closures self-contained).

- boot/Editor/Menu/MenuItem.php
- boot/Editor/Menu/MenuRegistry.php DTO + registry for editor menu entries. forDisplay($slot) returns items sorted by ascending position then registration order. Two built-in slots: 'sidebar' (summary.php) and 'profile' (header.php). Plugins can introduce more slots by adding their own template fragment.

- boot/Plugin/CorePlugins/CoreEditorPlugin.php First Plugin that exercises every Phase-4 hook:
  - Registers the five built-in modules (pages, profile, auth, settings, install) via $context->registerEditorModule().
  - Seeds MenuRegistry from $config['modules'] entries via $context->addEditorMenuItem(). Removing this plugin via $config['plugins']['disabled'] strips the editor surface entirely; the dispatch pipeline is identical for third-party plugins.

- boot/Plugin/PluginContext.php New registerEditorModule() and addEditorMenuItem() methods; the underlying registries are resolved from the container.

- boot/Editor/EditorRouter.php Refactored to dispatch via the registry. Auth gating remains hard-coded since it crosses every module; the api/* subtree stays inline since it has one endpoint today.

- editor/theme/summary.php
- editor/theme/header.php Switched from $editor->config['modules'] to the MenuRegistry. HTML structure unchanged; logout-suffix handling preserved by anchoring on the slug+label pair the CoreEditorPlugin seeds.

- boot.php Two discovery-loop fixes:
  - Binds Scriptor's $config to the container under 'scriptor.config' and the Scriptor root under 'scriptor.root'. Plugins need these at register() time, before per-request services (Editor, Site) exist.
  - Pre-instantiates ModuleRegistry + MenuRegistry as shared container services so the CoreEditorPlugin and any third-party plugin populate the same instances. Registers CoreEditorPlugin as the second core plugin alongside DbPagesResolverPlugin.

- boot/Editor/{Pages,Auth,Profile,Settings,Install}/*Module.php Add `implements Module` plus the corresponding use statement. No behavior changes.

Smoke (CLI, against host data/imanager.db):

  Booted plugins: 2
    - core/db-pages-resolver v1.0.0
    - core/editor v1.0.0

  Registered module slugs: pages, profile, auth, settings, install

  Sidebar items: pages (pos=0), settings (pos=2), install (pos=3)
  Profile items: profile (pos=1), auth/logout_menu (pos=1)

  Order and display_type filtering match the legacy
  $config['modules']-driven render exactly.

Plan reference: docs/scriptor-plugin-api-plan.md, section 3.6.
Next: scriptor-markdown-pages plugin extract (Phase 5, new repo).