### PR TITLE
feat(plugin): ContentRendering event for plugin-provided page HTML (P…

### DIFF
--- a/boot/Events/Frontend/ContentRendering.php
+++ b/boot/Events/Frontend/ContentRendering.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Events\Frontend;
+
+use Scriptor\Boot\Frontend\Page;
+
+/**
+ * Dispatched by {@see Scriptor\Boot\Frontend\Site::renderContent()} so
+ * plugins can substitute the rendered HTML for the resolved page.
+ *
+ * Listener slot is the mutable {@see $html} property:
+ *
+ * - If a listener sets `$event->html` to a non-null string, Site uses
+ *   that as the rendered content and skips the default Parsedown
+ *   sanitizer.
+ * - If no listener sets it, the standard
+ *   `$site->sanitizer->markdown($page->content)` pipeline runs.
+ *
+ * Cooperative convention: subsequent listeners should self-check by
+ * leaving `$event->html` untouched if a prior listener already filled
+ * it (first writer wins), unless they intentionally want to wrap the
+ * earlier output.
+ *
+ * Typical use cases:
+ *
+ * - Markdown-pages plugin: detects pages whose Item data carries its
+ *   marker and returns the CommonMark-rendered HTML it already
+ *   computed during PageResolving.
+ * - Shortcode plugin: lets the default Parsedown run, then this event
+ *   could come back with post-processed output if we ever add the
+ *   ability to peek at the in-flight content (today only the original
+ *   page is exposed).
+ */
+final class ContentRendering
+{
+    public ?string $html = null;
+
+    public function __construct(
+        public readonly Page $page,
+    ) {}
+}

--- a/boot/Frontend/Site.php
+++ b/boot/Frontend/Site.php
@@ -14,6 +14,7 @@ use Imanager\Templating\TemplateRenderer;
 use Imanager\Validation\Sanitizer as ImanagerSanitizer;
 use League\Container\Container;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Scriptor\Boot\Events\Frontend\ContentRendering;
 use Scriptor\Boot\Events\Frontend\PageResolved;
 use Scriptor\Boot\Events\Frontend\PageResolving;
 use Scriptor\Boot\Events\Frontend\RouteNotFound;
@@ -312,11 +313,21 @@ class Site
         if ($this->page === null) {
             return '';
         }
-        // Page content is stored as raw Markdown. Parsedown safe-mode
-        // escapes embedded HTML and rewrites non-whitelisted URL schemes
-        // (no `javascript:` etc.). A future plugin that introduces an
-        // alternative content format should dispatch on a per-page
-        // marker rather than reinstating a global flag here.
+
+        // Give plugins a shot at substituting the rendered content.
+        // The markdown-pages plugin, for instance, pre-computes
+        // CommonMark output during PageResolving and returns it here
+        // so its virtual pages don't get re-processed by Parsedown.
+        $dispatcher = $this->container->get(EventDispatcherInterface::class);
+        $event = new ContentRendering($this->page);
+        $dispatcher->dispatch($event);
+
+        if ($event->html !== null) {
+            return $event->html;
+        }
+
+        // Default path: Parsedown in safe mode (escapes embedded HTML,
+        // rejects non-whitelisted URL schemes).
         return $this->sanitizer->markdown($this->page->content);
     }
 


### PR DESCRIPTION
…hase 5a)

Ships the deferred ContentRendering event from the Plugin API plan (docs/scriptor-plugin-api-plan.md, section 3.5) so the upcoming scriptor-markdown-pages plugin can substitute CommonMark-rendered HTML for its virtual pages instead of pushing markdown through Parsedown twice.

What lands:

- boot/Events/Frontend/ContentRendering.php Carries the resolved Page (readonly) and a mutable ?string html slot. First listener to set a non-null value wins by convention.

- boot/Frontend/Site.php renderContent() now dispatches ContentRendering with the current page before falling back to the default Parsedown pipeline. If a listener fills $event->html, that string is returned verbatim; if no listener responds, the existing $sanitizer->markdown() call runs as before.

Smoke (CLI):

  // Fake listener substitutes HTML $provider->subscribe(ContentRendering::class, fn ($e) => $e->html = '<p>substituted by smoke</p>');

  $rendering = new ContentRendering($page); $dispatcher->dispatch($rendering); // → $rendering->html === '<p>substituted by smoke</p>'

Backward compatibility: every existing theme keeps working unchanged. With no subscribers, ContentRendering is dispatched but no listener fires; Site falls through to the same Parsedown call as before. The event's mutable slot pattern matches PageResolving / RouteNotFound, so the dispatch convention is uniform.

Next: bigins/scriptor-markdown-pages new repo (Phase 5b). The plugin will use this event together with PageResolving to migrate the InfoTheme-internal markdown route into a reusable Scriptor plugin.

Plan reference: docs/scriptor-plugin-api-plan.md, sections 3.5 + 4.