### PR TITLE
fix(plugin): auto-invalidate discovery cache when installed.json changes

### DIFF
--- a/boot/Plugin/PluginManager.php
+++ b/boot/Plugin/PluginManager.php
@@ -20,9 +20,12 @@ use League\Container\Container;
  *
  * Discovery results land in a PHP cache file (default
  * `data/cache/plugins.php`) so the installed.json scan does not run
- * on every request. Composer post-install / post-update scripts can
- * call {@see clearCache()} to invalidate after dependency changes;
- * in development a missing cache simply means one slow boot.
+ * on every request. Cache freshness is checked by comparing the
+ * mtime of the cache file with the mtime of `vendor/composer/installed.json`;
+ * any time composer rewrites installed.json (install, update, remove,
+ * dump-autoload) the next boot picks up the new state automatically.
+ * {@see clearCache()} stays available for callers that want to force
+ * a fresh scan explicitly.
  *
  * Disabling a discovered plugin without uninstalling it is possible
  * via `$config['plugins']['disabled']` in scriptor-config.php; the
@@ -187,6 +190,18 @@ final class PluginManager
     {
         if (! is_file($this->cachePath)) {
             return null;
+        }
+        // Self-invalidate when composer rewrites installed.json. Any
+        // composer install / update / remove / dump-autoload bumps the
+        // installed.json mtime, so the cache becomes stale the moment
+        // dependencies change. No external hook needed.
+        $installed = $this->vendorDir . '/composer/installed.json';
+        if (is_file($installed)) {
+            $installedMtime = (int) filemtime($installed);
+            $cacheMtime     = (int) filemtime($this->cachePath);
+            if ($installedMtime > $cacheMtime) {
+                return null;
+            }
         }
         $cached = @include $this->cachePath;
         if (! is_array($cached)) {


### PR DESCRIPTION
Phase 2 of the Plugin API shipped a PHP-array cache for the discovered plugin manifests under data/cache/plugins.php, but only an explicit clearCache() method. That left a real foot-gun:

  composer require some/new-scriptor-plugin
  # vendor/composer/installed.json now lists the plugin
  # vendor/<the plugin>/ is in place

  curl /...                        # plugin doesn't fire
  # → boot's PluginManager reads the stale cache, sees zero plugins,
  #   never re-scans installed.json. The new dependency stays
  #   invisible until the developer notices and deletes the cache.

I hit this exactly while wiring scriptor-markdown-pages today: the plugin was correctly installed but invisible until I rm-ed the cache file by hand. The right fix is for the cache to self-invalidate, not to bolt a composer post-install/update hook on top.

What lands:

- boot/Plugin/PluginManager.php readCache() now compares filemtime(installed.json) against filemtime(cache file). If installed.json is newer, the method returns null so the surrounding discover() falls through to scanInstalledJson() and re-writes the cache. Any composer operation that touches installed.json (install, update, remove, dump-autoload) bumps its mtime, so the next boot picks up the new state without external coordination.

  The mtime check is a single is_file + filemtime pair. Costs less than parsing 500KB of installed.json on every request, which is what naive un-caching would do. clearCache() stays available for callers that want to force a refresh anyway.

  Docblock updated to describe the new invalidation rule so future callers don't reach for a composer hook.

Smoke (CLI fixture with a tmp vendor dir):

  1) No cache yet, installed.json has 0 plugins → discover() returns 0, cache written. 2) installed.json bumped to 1 plugin, mtime forced newer → fresh PluginManager.discover() returns 1, cache rewritten. 3) Cache mtime forced newer than installed.json → discover() returns 1 (uses cache, no re-scan).

Backward compatibility: every existing caller works unchanged. Sites that already have a stale cache from before this fix re-scan once at next boot (because installed.json was almost certainly modified more recently than the cache write that produced the stale state).

No new Plugin API surface; closes the gap in Phase 2 itself.