### PR TITLE
chore(deps): bump bigins/scriptor-markdown-pages 0.1.0 -> 0.1.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -89,16 +89,16 @@
         },
         {
             "name": "bigins/scriptor-markdown-pages",
-            "version": "v0.1.0",
+            "version": "v0.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bigin/scriptor-markdown-pages.git",
-                "reference": "d1c40454c9c1fd3ded92b3d42dfd1cc8536383ec"
+                "reference": "f20f66b679c1a5eda42acc0764d6205a2654ea6e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bigin/scriptor-markdown-pages/zipball/d1c40454c9c1fd3ded92b3d42dfd1cc8536383ec",
-                "reference": "d1c40454c9c1fd3ded92b3d42dfd1cc8536383ec",
+                "url": "https://api.github.com/repos/bigin/scriptor-markdown-pages/zipball/f20f66b679c1a5eda42acc0764d6205a2654ea6e",
+                "reference": "f20f66b679c1a5eda42acc0764d6205a2654ea6e",
                 "shasum": ""
             },
             "require": {
@@ -139,10 +139,10 @@
                 "scriptor-plugin"
             ],
             "support": {
-                "source": "https://github.com/bigin/scriptor-markdown-pages/tree/v0.1.0",
+                "source": "https://github.com/bigin/scriptor-markdown-pages/tree/v0.1.1",
                 "issues": "https://github.com/bigin/scriptor-markdown-pages/issues"
             },
-            "time": "2026-05-19T05:40:34+00:00"
+            "time": "2026-05-19T07:30:50+00:00"
         },
         {
             "name": "dflydev/dot-access-data",


### PR DESCRIPTION
Picks up the editor-surface polish landed in the plugin repo:

- Sidebar entry now renders with the gg-copy icon (the previous gg-file-document was missing from the css-gg subset Scriptor ships).
- "Documentation" no longer appears twice on the page. Breadcrumb HTML feeds $editor->breadcrumbs (correct slot), pageContent carries a single H1 reflecting the section/document name.
- Directory listing replaces the 📁/📄 emojis with gg-list / gg-screen icons in a 2-column table that matches PagesModule's list shape.

composer.json constraint ^0.1 already accepts the patch bump, so the change is composer.lock only. Next docker image rebuild (local + Hetzner) picks the new plugin code up automatically; the in-container vendor regenerates from the lock file.