### PR TITLE
fix(editor): show breadcrumbs at tablet + split-window widths

### DIFF
--- a/public/editor-assets/css/styles.css
+++ b/public/editor-assets/css/styles.css
@@ -202,7 +202,13 @@ hr {
 .breadcrumbs li:first-child a, .breadcrumbs li:first-child span {
 	margin-left: 0;
 }
-@media (max-width: 1100px) {
+/* Hide breadcrumbs only on phone widths where the header cluster
+ * (hamburger toggle + profile menu) otherwise crowds the breadcrumb
+ * out of the row. At tablet and split-window desktop widths the
+ * breadcrumb fits and is genuinely useful (the sidebar collapses
+ * around 1100px, so a breadcrumb is the only "you are here"
+ * affordance left). */
+@media (max-width: 767px) {
 	.breadcrumbs {
 		display: none;
 	}


### PR DESCRIPTION
The editor's header breadcrumb was hidden on every viewport under 1100px wide. That threshold matches the desktop sidebar collapse, but the consequence is wrong: when the sidebar collapses to a hamburger, the breadcrumb is the ONLY "you are here" affordance the chrome offers. Hiding it on the same breakpoint deletes navigation context exactly when the user needs it most.

Concretely the bug showed up on /editor/pages/edit/?page=<id>: the PagesModule sets `$editor->breadcrumbs` to "Pages > Edit", but the header.php template's `<ul class="breadcrumbs">` block was hidden by CSS on any browser window narrower than 1100px (split-screen, 13-inch laptop in a side-by-side layout, narrow zoom, ...). I verified the PHP emits the right HTML; this is purely a stylesheet fix:

  $ docker exec ... php -r '...; $module->execute(); echo $editor->breadcrumbs;'
  <li><a href="../">Pages</a><i class="gg-chevron-right"></i></li>
  <li><span>New</span></li>

The 1100px threshold is otherwise used consistently across the editor stylesheet for the sidebar/content layout switch, so changing it everywhere would shift the broader layout. This fix only narrows the `@media (max-width: ...)` rule for `.breadcrumbs` from 1100px to 767px (a phone-width breakpoint where the header cluster genuinely crowds the breadcrumb out of the row).

What changes:

- public/editor-assets/css/styles.css `@media (max-width: 1100px) { .breadcrumbs { display: none } }` → `@media (max-width: 767px) { ... }` with an explanatory comment.

After this lands:

- Desktop (>=1100px): unchanged. Sidebar visible, breadcrumb visible.
- Tablet + split-window desktop (768-1099px): sidebar collapses to hamburger, breadcrumb now stays visible.
- Phone (<=767px): sidebar collapsed to hamburger, breadcrumb hidden.