### PR TITLE
feat(plugin): PluginsModule prefers Composer manifest version

### DIFF
--- a/boot/Editor/Plugins/PluginsModule.php
+++ b/boot/Editor/Plugins/PluginsModule.php
@@ -66,6 +66,14 @@ final class PluginsModule implements Module
             $regs = $this->pluginManager->registrationsFor($name) ?? [
                 'events' => [], 'modules' => [], 'menuItems' => [],
             ];
+            // Prefer the Composer manifest version over Plugin::version()
+            // for Composer-installed plugins. The manifest matches the
+            // git tag composer resolved; the hardcoded version() string
+            // is a footgun when a plugin author forgets to bump it in
+            // the release commit. Core plugins (no manifest) keep
+            // their own version() string.
+            $manifest = $this->pluginManager->manifestFor($name);
+            $version  = $manifest !== null ? $manifest->packageVersion : $plugin->version();
             $rows .= sprintf(
                 '<tr>'
                 . '<td><strong>%s</strong></td>'
@@ -75,7 +83,7 @@ final class PluginsModule implements Module
                 . '<td>%s</td>'
                 . '</tr>',
                 htmlspecialchars($name, \ENT_QUOTES),
-                htmlspecialchars($plugin->version(), \ENT_QUOTES),
+                htmlspecialchars($version, \ENT_QUOTES),
                 $this->renderEventList($regs['events']),
                 $this->renderModuleList($regs['modules']),
                 $this->renderMenuList($regs['menuItems']),

--- a/boot/Plugin/PluginManager.php
+++ b/boot/Plugin/PluginManager.php
@@ -42,6 +42,9 @@ final class PluginManager
     /** @var array<string, PluginContext> Per-plugin contexts, keyed by Plugin::name(). */
     private array $contexts = [];
 
+    /** @var array<string, PluginManifest> Manifests keyed by Plugin::name(); only set for Composer-discovered plugins. */
+    private array $manifestsByPluginName = [];
+
     /**
      * @param list<string> $disabled    FQCNs of plugins to skip at boot.
      * @param list<string> $corePlugins FQCNs of first-party plugins shipped
@@ -101,14 +104,14 @@ final class PluginManager
             return;
         }
         foreach ($this->corePlugins as $class) {
-            $this->bootPluginClass($class);
+            $this->bootPluginClass($class, null);
         }
         foreach ($this->discover() as $manifest) {
-            $this->bootPluginClass($manifest->pluginClass);
+            $this->bootPluginClass($manifest->pluginClass, $manifest);
         }
     }
 
-    private function bootPluginClass(string $class): void
+    private function bootPluginClass(string $class, ?PluginManifest $manifest): void
     {
         if (in_array($class, $this->disabled, true)) {
             return;
@@ -122,8 +125,11 @@ final class PluginManager
         }
         $context = new PluginContext($this->container, $instance->name());
         $instance->register($context);
-        $this->bootedPlugins[]                = $instance;
-        $this->contexts[$instance->name()]    = $context;
+        $this->bootedPlugins[]                  = $instance;
+        $this->contexts[$instance->name()]      = $context;
+        if ($manifest !== null) {
+            $this->manifestsByPluginName[$instance->name()] = $manifest;
+        }
     }
 
     /**
@@ -138,6 +144,19 @@ final class PluginManager
         return isset($this->contexts[$pluginName])
             ? $this->contexts[$pluginName]->registrations()
             : null;
+    }
+
+    /**
+     * Returns the Composer manifest for the named plugin, or null
+     * for core plugins (which ship with Scriptor and have no
+     * installed.json record). The PluginsModule editor surface
+     * prefers the manifest version over Plugin::version() to avoid
+     * the source-string-drift the early plugin releases had to
+     * correct one-by-one.
+     */
+    public function manifestFor(string $pluginName): ?PluginManifest
+    {
+        return $this->manifestsByPluginName[$pluginName] ?? null;
     }
 
     /** @return list<Plugin> */


### PR DESCRIPTION
Rooted-out fix for a string-drift footgun the plugin api currently has. A Composer-installed plugin ships two version strings:

1. The git tag composer resolved (in vendor/composer/installed.json).
2. The hardcoded string Plugin::version() returns.

These can drift trivially. Yesterday's polish PR bumped the plugin to v0.1.3 but forgot to update Plugin::version() in the same commit, so the PluginsModule editor surface kept showing "v0.1.2" while composer reported v0.1.3. I bumped to fix it once already (v0.1.0 -> v0.1.1 patch), and the same drift came back with v0.1.2 -> v0.1.3. Two release cycles to chase down one wrong string is a smell.

Fix at the consumer end instead of the publisher end: trust the manifest. The Composer manifest is the authoritative source (it mirrors the tag the package manager resolved), and a plugin author no longer has to remember to keep two strings in sync. Plugin::version() becomes informational for core plugins (which ship inside Scriptor and have no manifest) and a fallback for Composer plugins that have not been Composer-installed via the auto-discovery path (legacy paths).

What lands:

- boot/Plugin/PluginManager.php Adds a $manifestsByPluginName map populated during bootPluginClass() whenever the plugin was discovered through installed.json. New manifestFor(string $pluginName) accessor returns the manifest or null (for core plugins).

- boot/Editor/Plugins/PluginsModule.php renderBootedRows() now resolves the version via $manager->manifestFor()?->packageVersion ?? $plugin->version(). Manifest wins when present; core plugins keep using their own hardcoded version() string.

Smoke (CLI, fresh cache):
  core/db-pages-resolver           v=1.0.0
  core/editor                      v=1.0.0
  bigins/scriptor-markdown-pages   v=v0.1.2  (from manifest; the
                                              plugin's own Plugin::version()
                                              still says "0.1.2" too, in
                                              sync today; tag v0.1.3 hasn't
                                              been pulled into Scriptor's
                                              lock yet -- that's the next PR.)

The next PR bumps composer.lock to v0.1.3 and the smoke will then show v0.1.3 from the manifest -- even though that plugin release contains a still-stale Plugin::version() == "0.1.2". That is the whole point: the manager removes the dependency on the publisher keeping the string in sync.