### PR TITLE
chore(deps): bump bigins/scriptor-markdown-pages 0.1.2 -> 0.1.3

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -89,16 +89,16 @@
         },
         {
             "name": "bigins/scriptor-markdown-pages",
-            "version": "v0.1.2",
+            "version": "v0.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bigin/scriptor-markdown-pages.git",
-                "reference": "2abae8024b9458c855b19aaede157eb07750102e"
+                "reference": "fb3a91f99b46bc922a6df9094dda5518ac9ce307"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bigin/scriptor-markdown-pages/zipball/2abae8024b9458c855b19aaede157eb07750102e",
-                "reference": "2abae8024b9458c855b19aaede157eb07750102e",
+                "url": "https://api.github.com/repos/bigin/scriptor-markdown-pages/zipball/fb3a91f99b46bc922a6df9094dda5518ac9ce307",
+                "reference": "fb3a91f99b46bc922a6df9094dda5518ac9ce307",
                 "shasum": ""
             },
             "require": {
@@ -139,10 +139,10 @@
                 "scriptor-plugin"
             ],
             "support": {
-                "source": "https://github.com/bigin/scriptor-markdown-pages/tree/v0.1.2",
+                "source": "https://github.com/bigin/scriptor-markdown-pages/tree/v0.1.3",
                 "issues": "https://github.com/bigin/scriptor-markdown-pages/issues"
             },
-            "time": "2026-05-19T09:04:10+00:00"
+            "time": "2026-05-19T09:49:24+00:00"
         },
         {
             "name": "dflydev/dot-access-data",


### PR DESCRIPTION
Pulls in the three editor + frontend polish fixes:

- Heading anchors: the visible "#" symbol next to every <h2>/<h3>
  is gone. URL fragments still work because each heading carries an
  id attribute (added by the plugin's renderer as a post-process
  step).
- Breadcrumb chevron: now lives inside the previous link's <li>, matching PagesModule and the editor's `.breadcrumbs li` layout contract so the chevron sits inline with the link text instead of floating above the row.
- Directory listings include siblings: /editor/docs/<track>/ now renders the _index.md content AS WELL AS the sibling file list (previously the listing was skipped when _index.md existed, so welcome.md and friends were invisible from the dir URL).

Note: plugin v0.1.3's Plugin::version() string still returns "0.1.2" (stale from the previous release). Combined with the parallel feat/plugin-manifest-version PR (#82 once merged), the PluginsModule editor surface will read the version from the Composer manifest instead, so the display says v0.1.3 regardless of what the plugin code self-reports. That is exactly the architectural fix that removes the drift footgun going forward.