### PR TITLE
feat(plugin): FrontendNavRegistry for plugin-contributed nav

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Scriptor\Boot\App;
 use Scriptor\Boot\Editor\Menu\MenuRegistry;
 use Scriptor\Boot\Editor\ModuleRegistry;
+use Scriptor\Boot\Frontend\Nav\FrontendNavRegistry;
 use Scriptor\Boot\ImanagerBootstrap;
 use Scriptor\Boot\Plugin\PluginManager;
 
@@ -31,6 +32,12 @@ App::container()->addShared(
 // templates read MenuRegistry to render the sidebar and profile cluster.
 App::container()->addShared(ModuleRegistry::class, static fn() => new ModuleRegistry());
 App::container()->addShared(MenuRegistry::class,   static fn() => new MenuRegistry());
+
+// Frontend nav registry. Plugins contribute builder callables via
+// PluginContext::contributeFrontendNav(); themes resolve this service
+// and call collect($urlSegments) to get the merged NavItem tree for
+// the current request. Stays empty until a plugin populates it.
+App::container()->addShared(FrontendNavRegistry::class, static fn() => new FrontendNavRegistry());
 
 /*
  * Boot path:

--- a/boot/Editor/Plugins/PluginsModule.php
+++ b/boot/Editor/Plugins/PluginsModule.php
@@ -64,7 +64,7 @@ final class PluginsModule implements Module
         foreach ($booted as $plugin) {
             $name = $plugin->name();
             $regs = $this->pluginManager->registrationsFor($name) ?? [
-                'events' => [], 'modules' => [], 'menuItems' => [],
+                'events' => [], 'modules' => [], 'menuItems' => [], 'navBuilders' => 0,
             ];
             // Prefer the Composer manifest version over Plugin::version()
             // for Composer-installed plugins. The manifest matches the

--- a/boot/Frontend/Nav/FrontendNavRegistry.php
+++ b/boot/Frontend/Nav/FrontendNavRegistry.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Frontend\Nav;
+
+use Imanager\Http\UrlSegments;
+
+/**
+ * Plugin-contributed frontend navigation. Plugins register builder
+ * callables via {@see \Scriptor\Boot\Plugin\PluginContext::contributeFrontendNav()};
+ * each builder is called once per request with the current
+ * {@see UrlSegments} and returns a list of top-level {@see NavItem}
+ * nodes (possibly nested).
+ *
+ * The registry produces a flat list of top-level NavItems at
+ * `collect()` time, sorted by ascending position and stable on
+ * registration order for ties. The theme renders the list; active /
+ * current state is the theme's concern.
+ *
+ * Why a builder callable instead of a static NavItem list:
+ *
+ * - A plugin's nav often depends on the request URL (for example,
+ *   the markdown-pages plugin expands the active track's filesystem
+ *   children but leaves the other tracks collapsed). A builder that
+ *   sees the URL can emit different shapes for different requests
+ *   without the registry having to expose a "current request" hook.
+ * - The registry stays simple: no event system, no priorities beyond
+ *   the explicit `position` field.
+ */
+final class FrontendNavRegistry
+{
+    /** @var list<callable(UrlSegments): array<int, NavItem>> */
+    private array $builders = [];
+
+    /**
+     * @param callable(UrlSegments): array<int, NavItem> $builder
+     */
+    public function contribute(callable $builder): void
+    {
+        $this->builders[] = $builder;
+    }
+
+    /**
+     * Build the merged, sorted top-level NavItem list for the given
+     * request URL. Non-NavItem entries returned by a builder are
+     * silently dropped.
+     *
+     * @return list<NavItem>
+     */
+    public function collect(UrlSegments $url): array
+    {
+        $entries = [];
+        $regIndex = 0;
+        foreach ($this->builders as $builder) {
+            $items = $builder($url);
+            if (! is_iterable($items)) {
+                continue;
+            }
+            foreach ($items as $item) {
+                if (! $item instanceof NavItem) {
+                    continue;
+                }
+                $entries[] = [$item->position, $regIndex++, $item];
+            }
+        }
+        usort($entries, static function (array $a, array $b): int {
+            if ($a[0] !== $b[0]) {
+                return $a[0] <=> $b[0];
+            }
+            return $a[1] <=> $b[1];
+        });
+        return array_map(static fn (array $e): NavItem => $e[2], $entries);
+    }
+
+    /**
+     * Number of registered contributors. Used by the PluginsModule
+     * editor surface to report per-plugin counts.
+     */
+    public function contributorCount(): int
+    {
+        return count($this->builders);
+    }
+}

--- a/boot/Frontend/Nav/NavItem.php
+++ b/boot/Frontend/Nav/NavItem.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Frontend\Nav;
+
+/**
+ * One node in the frontend navigation tree contributed by a plugin.
+ *
+ * URL is either absolute (`https://...`) or rooted (`/developer-guide/`);
+ * the rendering theme is responsible for prepending site URL when it
+ * sees a leading slash. Position is the sort key used by
+ * {@see FrontendNavRegistry::collect()}: lower wins. Children allow
+ * arbitrary nesting; a content tree (markdown pages, blog posts,
+ * external links, ...) maps cleanly onto this shape.
+ *
+ * Active / current state is a render-time concern, not a data
+ * concern, so this DTO carries no `isActive` / `isCurrent` flags.
+ * The renderer compares each item's URL against the request URL.
+ */
+final readonly class NavItem
+{
+    /**
+     * @param list<NavItem> $children
+     */
+    public function __construct(
+        public string $url,
+        public string $label,
+        public int $position = 0,
+        public array $children = [],
+    ) {}
+}

--- a/boot/Plugin/PluginContext.php
+++ b/boot/Plugin/PluginContext.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Scriptor\Boot\Plugin;
 
 use Imanager\Events\SubscriberListenerProvider;
+use Imanager\Http\UrlSegments;
 use League\Container\Container;
 use Scriptor\Boot\Editor\Editor;
 use Scriptor\Boot\Editor\Menu\MenuItem;
 use Scriptor\Boot\Editor\Menu\MenuRegistry;
 use Scriptor\Boot\Editor\Module;
 use Scriptor\Boot\Editor\ModuleRegistry;
+use Scriptor\Boot\Frontend\Nav\FrontendNavRegistry;
+use Scriptor\Boot\Frontend\Nav\NavItem;
 
 /**
  * Registration surface handed to every plugin's {@see Plugin::register()}.
@@ -39,6 +42,9 @@ final class PluginContext
 
     /** @var list<MenuItem> Editor menu items this plugin added. */
     private array $menuItems = [];
+
+    /** @var int Frontend nav builders this plugin contributed. */
+    private int $navBuilderCount = 0;
 
     public function __construct(
         private readonly Container $container,
@@ -95,17 +101,41 @@ final class PluginContext
     }
 
     /**
+     * Contribute a frontend nav builder. The builder runs once per
+     * request with the current {@see UrlSegments} and returns a list
+     * of top-level {@see NavItem} nodes (optionally nested via
+     * `NavItem::$children`). Themes that consume the frontend nav
+     * ask {@see FrontendNavRegistry::collect()} for the merged tree;
+     * the registry sorts entries by `position` then registration
+     * order.
+     *
+     * Plugins that own a content tree (markdown pages, blog posts,
+     * external links, ...) should contribute through this hook
+     * instead of asking themes to walk plugin-owned directories.
+     *
+     * @param callable(UrlSegments): array<int, NavItem> $builder
+     */
+    public function contributeFrontendNav(callable $builder): void
+    {
+        $this->navBuilderCount++;
+        /** @var FrontendNavRegistry $registry */
+        $registry = $this->container->get(FrontendNavRegistry::class);
+        $registry->contribute($builder);
+    }
+
+    /**
      * Snapshot of what this plugin registered. Used by the editor's
      * InstalledPluginsModule to render a per-plugin breakdown.
      *
-     * @return array{events: list<string>, modules: list<string>, menuItems: list<MenuItem>}
+     * @return array{events: list<string>, modules: list<string>, menuItems: list<MenuItem>, navBuilders: int}
      */
     public function registrations(): array
     {
         return [
-            'events'    => $this->events,
-            'modules'   => $this->modules,
-            'menuItems' => $this->menuItems,
+            'events'      => $this->events,
+            'modules'     => $this->modules,
+            'menuItems'   => $this->menuItems,
+            'navBuilders' => $this->navBuilderCount,
         ];
     }
 }

--- a/boot/Plugin/PluginManager.php
+++ b/boot/Plugin/PluginManager.php
@@ -137,7 +137,7 @@ final class PluginManager
      * if the plugin is not booted (disabled, missing class, or never
      * discovered).
      *
-     * @return array{events: list<string>, modules: list<string>, menuItems: list<\Scriptor\Boot\Editor\Menu\MenuItem>}|null
+     * @return array{events: list<string>, modules: list<string>, menuItems: list<\Scriptor\Boot\Editor\Menu\MenuItem>, navBuilders: int}|null
      */
     public function registrationsFor(string $pluginName): ?array
     {


### PR DESCRIPTION
Plugins that own a content tree (markdown pages, blog posts, external links) need to contribute frontend navigation entries without asking themes to walk plugin-owned directories. This adds the registration surface.

- NavItem: readonly DTO carrying url + label + position + nested children. No active/current flags; that is a render-time concern.
- FrontendNavRegistry: collects builder callables; collect() invokes each builder with the current UrlSegments and returns the merged top-level list, sorted by position then registration order.
- PluginContext::contributeFrontendNav(): the hook plugins call in register(). Tracks builder count on the context for the PluginsModule diagnostics shape.
- boot.php: binds FrontendNavRegistry as a shared container service.
- PluginsModule + PluginManager docblocks: extend the registrations shape with navBuilders count so consumers stay type-consistent.

Empty until a plugin contributes. Theme + plugin consumers ship in the follow-up PRs (scriptor-markdown-pages nav builder, then InfoTheme consumes the registry).