### PR TITLE
chore(deps): bump bigins/scriptor-markdown-pages 0.1.3 -> 0.1.4

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -89,16 +89,16 @@
         },
         {
             "name": "bigins/scriptor-markdown-pages",
-            "version": "v0.1.3",
+            "version": "v0.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bigin/scriptor-markdown-pages.git",
-                "reference": "fb3a91f99b46bc922a6df9094dda5518ac9ce307"
+                "reference": "2cd180b6448b531c9af4c76090439498a636997d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bigin/scriptor-markdown-pages/zipball/fb3a91f99b46bc922a6df9094dda5518ac9ce307",
-                "reference": "fb3a91f99b46bc922a6df9094dda5518ac9ce307",
+                "url": "https://api.github.com/repos/bigin/scriptor-markdown-pages/zipball/2cd180b6448b531c9af4c76090439498a636997d",
+                "reference": "2cd180b6448b531c9af4c76090439498a636997d",
                 "shasum": ""
             },
             "require": {
@@ -139,10 +139,10 @@
                 "scriptor-plugin"
             ],
             "support": {
-                "source": "https://github.com/bigin/scriptor-markdown-pages/tree/v0.1.3",
+                "source": "https://github.com/bigin/scriptor-markdown-pages/tree/v0.1.4",
                 "issues": "https://github.com/bigin/scriptor-markdown-pages/issues"
             },
-            "time": "2026-05-19T09:49:24+00:00"
+            "time": "2026-05-19T13:06:51+00:00"
         },
         {
             "name": "dflydev/dot-access-data",


### PR DESCRIPTION
Picks up the new NavBuilder that contributes per-track entries to the FrontendNavRegistry shipped on master. With this lock the plugin sees the registry surface and Scriptor's container resolves the contributed builder during PluginManager::bootAll().

End-to-end smoke confirms: plugin booted as v0.1.4, manifestFor() matches the tag, FrontendNavRegistry::contributorCount() = 1, and collect() emits all 5 configured tracks as top-level NavItems.

Theme consumption (renderHierarchicalNavigation reading the registry instead of the flat top_nav_tracks config) ships in the matching scriptor-cms-ops PR.