### PR TITLE
feat(editor): per-page Position field + midpoint drag-reorder

### DIFF
--- a/boot/Editor/Pages/PagesModule.php
+++ b/boot/Editor/Pages/PagesModule.php
@@ -164,13 +164,21 @@ final class PagesModule implements Module
         $data['template']   = $template;
         $data['pagetype']   = $data['pagetype'] ?? '1';
 
+        // Position: form may set an explicit value (lets editors mix
+        // DB pages with plugin-contributed nav entries on one scale).
+        // Empty / 0 falls back to keep-existing (edit) or next-free (new).
+        $positionInput = $this->editor->input->postInt('position', 0);
+        $position = $positionInput > 0
+            ? $positionInput
+            : ($existing?->item->position ?? $this->pages->nextPosition());
+
         $now = time();
         $item = new Item(
             id:         $existing?->id(),
             categoryId: $this->pages->categoryId,
             name:       $name,
             label:      $existing?->item->label,
-            position:   $existing?->item->position ?? $this->pages->nextPosition(),
+            position:   $position,
             active:     $active,
             data:       $data,
             created:    $existing?->item->created ?? $now,
@@ -316,7 +324,17 @@ final class PagesModule implements Module
                 $ids[] = $int;
             }
         }
-        $this->pages->renumber($ids);
+        // The JS drag-handler sends the moved id explicitly so the
+        // server can reposition just that one row (midpoint between
+        // its new neighbours) instead of renumbering everything
+        // contiguously. Falling back to the old bulk-renumber path
+        // when `moved` is absent keeps any stale page-loads working.
+        $movedId = $this->editor->input->postInt('moved', 0);
+        if ($movedId > 0) {
+            $this->pages->reorderOne($movedId, $ids);
+        } else {
+            $this->pages->renumber($ids);
+        }
         $this->jsonResponse(['status' => 1]);
     }
 
@@ -362,15 +380,16 @@ final class PagesModule implements Module
             }
             $rows .= sprintf(
                 '<tr class="sortable">'
-                . '<td><i class="gg-swap-vertical"></i><input type="hidden" name="position[]" value="%d"></td>'
-                . '<td>%d</td><td>%s</td>'
-                . '<td><a href="edit/?page=%1$d">%s</a></td>'
-                . '<td><a class="remove" rel="%s" href="delete/?page=%1$d&amp;tokenName=pages&amp;tokenValue=%s"><i class="gg-trash"></i></a></td>'
+                . '<td><i class="gg-swap-vertical"></i> <span class="page-position">%2$d</span><input type="hidden" name="position[]" value="%1$d"></td>'
+                . '<td>%1$d</td>'
+                . '<td><a href="edit/?page=%1$d">%3$s</a></td>'
+                . '<td>%4$s</td>'
+                . '<td><a class="remove" rel="%5$s" href="delete/?page=%1$d&amp;tokenName=pages&amp;tokenValue=%6$s"><i class="gg-trash"></i></a></td>'
                 . '</tr>',
                 $page->id(),
-                $page->id(),
-                $parentCell,
+                $page->item->position,
                 htmlspecialchars($this->truncate($page->name, 80), \ENT_QUOTES),
+                $parentCell,
                 htmlspecialchars($this->t('pre_delete_msg'), \ENT_QUOTES),
                 rawurlencode($token),
             );
@@ -412,6 +431,7 @@ final class PagesModule implements Module
         $html .= $this->renderImagesSection($page);
         $html .= $this->fieldSelect('parent', 'parent', $this->t('parent_label'), $parentOptions);
         $html .= $this->fieldText('template', 'template', $this->t('template_label'), $page?->template ?? '', infoText: $this->t('template_field_infotext'));
+        $html .= $this->fieldPosition($page);
         $html .= $this->fieldCheckbox('publish', 'published', $this->t('published_label'), $page?->active() ?? true);
         $html .= '<input type="hidden" name="action" value="save-page">';
         $html .= sprintf('<input type="hidden" name="tokenName" value="%s">', htmlspecialchars('pages', \ENT_QUOTES));
@@ -576,6 +596,29 @@ final class PagesModule implements Module
         );
     }
 
+    /**
+     * Position number input. Empty value on the form leaves the page's
+     * current position untouched. The top-level nav merges DB pages
+     * with plugin-contributed entries by `position`, so editors with
+     * mixed nav can set explicit values here without drag-reordering.
+     */
+    private function fieldPosition(?Page $page): string
+    {
+        $label = $this->t('position_label') ?: 'Position';
+        $info  = $this->t('position_field_infotext')
+            ?: 'Sort key for the top-level navigation. Lower numbers come first. Leave empty to keep the current value.';
+        $value = $page !== null ? (string) $page->item->position : '';
+        return sprintf(
+            '<div class="form-control"><label for="position">%s</label>'
+            . '<p class="info-text i-wrapp"><i class="gg-danger"></i>%s</p>'
+            . '<input name="position" id="position" type="number" min="1" value="%s">'
+            . '</div>',
+            htmlspecialchars($label, \ENT_QUOTES),
+            htmlspecialchars($info, \ENT_QUOTES),
+            htmlspecialchars($value, \ENT_QUOTES),
+        );
+    }
+
     private function fieldCheckbox(string $id, string $name, string $label, bool $checked): string
     {
         return sprintf(
@@ -597,8 +640,8 @@ final class PagesModule implements Module
             . '<table id="page-list-table"><thead><tr>'
             . '<th><b>' . $i($this->t('position_table_header')) . '</b></th>'
             . '<th><b>' . $i($this->t('id_table_header')) . '</b></th>'
-            . '<th><b>' . $i($this->t('parent_table_header')) . '</b></th>'
             . '<th><b>' . $i($this->t('title_table_header')) . '</b></th>'
+            . '<th><b>' . $i($this->t('parent_table_header')) . '</b></th>'
             . '<th><b>' . $i($this->t('delete_table_header')) . '</b></th>'
             . '</tr></thead><tbody>' . $rows . '</tbody></table>'
             . '<input type="hidden" name="action" value="renumber-pages">'

--- a/boot/Frontend/PageRepository.php
+++ b/boot/Frontend/PageRepository.php
@@ -177,9 +177,116 @@ final readonly class PageRepository
     }
 
     /**
+     * Reposition a single page (the one the user just dragged) to sit
+     * directly before its new next-neighbour, without touching any
+     * other page's `position`. The new value is `nextPos - 1`; if the
+     * moved item lands at the end of the list it takes `prevPos + 1`.
+     *
+     * Used by `PagesModule::renumberAction()` when JS sends the explicit
+     * `moved` id alongside the new visual order — single-item drag is
+     * the common case and this preserves any manually-set positions on
+     * the other rows.
+     *
+     * If the gap between neighbours is too tight (`nextPos - prevPos < 2`),
+     * this cascade-shifts every following item by `+10` so the moved item
+     * still ends up just before the (shifted) next-neighbour.
+     *
+     * @param list<int> $idsInOrder Full top-level page id list in the
+     *                              new visual order (drag-end snapshot).
+     */
+    public function reorderOne(int $movedId, array $idsInOrder): void
+    {
+        $movedIndex = array_search($movedId, $idsInOrder, true);
+        if ($movedIndex === false) {
+            return;
+        }
+        $moved = $this->items->find($movedId);
+        if ($moved === null || $moved->categoryId !== $this->categoryId) {
+            return;
+        }
+
+        $prevPos = 0;
+        if ($movedIndex > 0) {
+            $prevItem = $this->items->find($idsInOrder[$movedIndex - 1]);
+            if ($prevItem !== null && $prevItem->categoryId === $this->categoryId) {
+                $prevPos = $prevItem->position;
+            }
+        }
+
+        $nextPos = null;
+        $nextIndex = $movedIndex + 1;
+        if ($nextIndex < count($idsInOrder)) {
+            $nextItem = $this->items->find($idsInOrder[$nextIndex]);
+            if ($nextItem !== null && $nextItem->categoryId === $this->categoryId) {
+                $nextPos = $nextItem->position;
+            }
+        }
+
+        if ($nextPos === null) {
+            // End of list: sit just after prev.
+            $newPos = $prevPos + 1;
+        } elseif ($nextPos - $prevPos >= 2) {
+            // Room exists: sit directly before next.
+            $newPos = $nextPos - 1;
+        } else {
+            // Neighbours touch (e.g. 5 and 6): moved item takes next's
+            // slot; next then bumps up by 1, and the ripple walks
+            // forward only as far as collisions actually exist. The
+            // first item with a position already higher than its new
+            // predecessor stops the cascade. Result: 1/2/3/4 → drag
+            // c between a and b → 1/2/3/4 (only b shifts by 1, d
+            // untouched).
+            $newPos = $nextPos;
+            $prevAssigned = $newPos;
+            for ($i = $nextIndex; $i < count($idsInOrder); $i++) {
+                $cascadeItem = $this->items->find($idsInOrder[$i]);
+                if ($cascadeItem === null || $cascadeItem->categoryId !== $this->categoryId) {
+                    continue;
+                }
+                if ($cascadeItem->position > $prevAssigned) {
+                    break; // gap reached
+                }
+                $newCascadePos = $prevAssigned + 1;
+                $this->items->save(new Item(
+                    id:         $cascadeItem->id,
+                    categoryId: $cascadeItem->categoryId,
+                    name:       $cascadeItem->name,
+                    label:      $cascadeItem->label,
+                    position:   $newCascadePos,
+                    active:     $cascadeItem->active,
+                    data:       $cascadeItem->data,
+                    created:    $cascadeItem->created,
+                    updated:    $cascadeItem->updated,
+                ));
+                $prevAssigned = $newCascadePos;
+            }
+        }
+
+        if ($moved->position === $newPos) {
+            return;
+        }
+
+        $this->items->save(new Item(
+            id:         $moved->id,
+            categoryId: $moved->categoryId,
+            name:       $moved->name,
+            label:      $moved->label,
+            position:   $newPos,
+            active:     $moved->active,
+            data:       $moved->data,
+            created:    $moved->created,
+            updated:    $moved->updated,
+        ));
+    }
+
+    /**
      * Bulk-renumber pages in the given order. Each id's `position`
      * becomes its (1-indexed) slot in the array. Pages absent from the
      * id list keep their current position.
+     *
+     * Kept for backwards compatibility (e.g. seed imports or admin
+     * tooling that wants explicit contiguous numbering). The interactive
+     * drag-reorder no longer calls this; it uses {@see reorderOne()}.
      *
      * @param list<int> $idsInOrder
      */

--- a/public/editor-assets/css/styles.css
+++ b/public/editor-assets/css/styles.css
@@ -679,6 +679,35 @@ label.required:after {
 	cursor: all-scroll;
 }
 
+/* css.gg ships `.gg-swap-vertical` as `display: block`, which would
+ * push the position badge onto its own line in the drag-handle cell.
+ * Override it to inline-block in the page list only, so the icon and
+ * the badge sit side-by-side on one baseline. */
+#page-list-table .sortable td:first-child {
+	white-space: nowrap;
+}
+#page-list-table .sortable td:first-child .gg-swap-vertical {
+	display: inline-block;
+	vertical-align: middle;
+}
+
+/* Position badge next to the drag handle. `tabular-nums` keeps the
+ * numbers right-aligned across rows so a column of values lines up
+ * cleanly regardless of digit count. */
+.page-position {
+	display: inline-block;
+	min-width: 2.5em;
+	margin-left: 2px;
+	padding: 1px 6px;
+	border-radius: var(--radius-sm, 4px);
+	background: var(--color-surface-alt);
+	color: var(--color-fg-muted);
+	font-size: var(--font-size-sm);
+	font-variant-numeric: tabular-nums;
+	text-align: right;
+	vertical-align: middle;
+}
+
 /* Item list not sortable */
 
 .item-table {

--- a/public/editor-assets/scripts/editor.js
+++ b/public/editor-assets/scripts/editor.js
@@ -55,9 +55,15 @@
 			},
 		});
 	};
-	function renumberPages() {
+	function renumberPages(movedId) {
 		var form = $("#page-list-form");
 		var formData = new FormData(document.querySelector("#page-list-form"));
+		// Tells the server which row was just dragged so it can reposition
+		// only that row (midpoint between its new neighbours) instead of
+		// renumbering everything contiguously.
+		if (movedId) {
+			formData.append("moved", movedId);
+		}
 		sendData(form.attr("action"), formData, function(result) {
 			//console.log(result);
 			if(result && result.status == 1) { return true; }
@@ -162,7 +168,8 @@
 		items:"tr.sortable",
 		handle:"td",
 		update:function(e,ui) {
-			renumberPages();
+			var movedId = ui.item.find('input[name="position[]"]').val();
+			renumberPages(movedId);
 		}
 	}).disableSelection();
 


### PR DESCRIPTION
Adds an explicit Position number input to the page edit form so editors can mix DB pages with plugin-contributed nav entries on one ordering scale (e.g. interleave DB pages between markdown tracks contributed via FrontendNavRegistry).

Drag-reorder no longer renumbers all top-level pages contiguously to 1/2/3/4. Instead the JS handler tells the server which row was moved; PageRepository::reorderOne() places the dragged item directly before its new next-neighbour (`nextPos - 1`), or applies a minimal +1 cascade walking forward only as far as adjacent siblings actually collide. Manually-set positions on other rows are preserved across drags. The legacy contiguous renumber() stays for stale page-loads that POST without the `moved` field.

The page list now renders each page's position as a small muted badge next to the drag handle (tabular-nums so digits align across rows).