### PR TITLE
fix(editor): live-update position badges on drag, transparent badge

### DIFF
--- a/boot/Editor/Pages/PagesModule.php
+++ b/boot/Editor/Pages/PagesModule.php
@@ -335,7 +335,17 @@ final class PagesModule implements Module
         } else {
             $this->pages->renumber($ids);
         }
-        $this->jsonResponse(['status' => 1]);
+        // Return the fresh id→position map so the client can update the
+        // visible badges without a full page reload. Only the ids that
+        // were submitted (i.e. currently rendered) are included.
+        $positions = [];
+        foreach ($ids as $id) {
+            $page = $this->pages->find($id);
+            if ($page !== null) {
+                $positions[(string) $id] = $page->item->position;
+            }
+        }
+        $this->jsonResponse(['status' => 1, 'positions' => $positions]);
     }
 
     private function markdownPreviewAction(): void

--- a/public/editor-assets/css/styles.css
+++ b/public/editor-assets/css/styles.css
@@ -699,8 +699,7 @@ label.required:after {
 	min-width: 2.5em;
 	margin-left: 2px;
 	padding: 1px 6px;
-	border-radius: var(--radius-sm, 4px);
-	background: var(--color-surface-alt);
+	background: transparent;
 	color: var(--color-fg-muted);
 	font-size: var(--font-size-sm);
 	font-variant-numeric: tabular-nums;

--- a/public/editor-assets/scripts/editor.js
+++ b/public/editor-assets/scripts/editor.js
@@ -65,8 +65,15 @@
 			formData.append("moved", movedId);
 		}
 		sendData(form.attr("action"), formData, function(result) {
-			//console.log(result);
-			if(result && result.status == 1) { return true; }
+			if (result && result.status == 1 && result.positions) {
+				$('#page-list-table tr.sortable').each(function() {
+					var row = $(this);
+					var id = row.find('input[name="position[]"]').val();
+					if (id && result.positions[id] !== undefined) {
+						row.find('.page-position').text(result.positions[id]);
+					}
+				});
+			}
 		});
 	}
 	function fixWidthHelper(e, ui) {


### PR DESCRIPTION
renumberAction returns the fresh id->position map so the client can patch the badges inline without a full reload. Drop the badge background/border-radius so the number sits cleanly next to the drag handle.