### PR TITLE
feat(editor): one-click copy of Markdown image construct

### DIFF
--- a/boot/Editor/Pages/PagesModule.php
+++ b/boot/Editor/Pages/PagesModule.php
@@ -535,12 +535,20 @@ final class PagesModule implements Module
         $titleField    = 'image_titles[' . $id . ']';
         $positionField = 'image_positions[' . $id . ']';
 
+        $altText = $file->title !== '' ? $file->title : '';
+        $markdown = '![' . $altText . '](' . $assetUrl . ')';
         return '<li class="image-list__item" data-file-id="' . $id . '">'
             . '<a href="' . $i($assetUrl) . '" target="_blank">'
             . '<img src="' . $i($thumbUrl) . '" alt="' . $i($file->name) . '" loading="lazy" width="120" height="120">'
             . '</a>'
             . ' <div class="image-list__meta">'
                 . '<code>' . $i($file->name) . '</code> '
+                . '<button type="button" class="image-list__copy"'
+                    . ' data-copy-md="' . $i($markdown) . '"'
+                    . ' data-copy-path="' . $i($assetUrl) . '"'
+                    . ' title="Copy Markdown — Shift+Click for path only">'
+                    . '<i class="gg-copy"></i><span class="image-list__copy-label">copy</span>'
+                . '</button> '
                 . '<span class="muted">(' . $file->width . 'x' . $file->height . ', ' . $file->size . ' bytes)</span>'
                 . '<div class="image-list__title-edit">'
                     . '<input type="text" class="image-list__title-input"'

--- a/public/editor-assets/css/styles.css
+++ b/public/editor-assets/css/styles.css
@@ -1180,6 +1180,36 @@ ul.messages {
 .image-list__meta > code {
 	word-break: break-all;
 }
+/* Copy-to-clipboard button next to the filename. Default click
+ * yields the full Markdown `![<title>](<path>)`; Shift+Click yields
+ * just the path. JS swaps the label to "copied" / "path copied"
+ * for ~1.2s. */
+.image-list__copy {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	margin-left: 4px;
+	padding: 2px 6px;
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-sm, 4px);
+	background: transparent;
+	color: var(--color-fg-muted);
+	font-size: var(--font-size-sm);
+	cursor: pointer;
+	vertical-align: middle;
+}
+.image-list__copy:hover {
+	color: var(--color-fg);
+	border-color: var(--color-fg-muted);
+}
+.image-list__copy.is-copied {
+	color: var(--color-success, #2a8a4a);
+	border-color: var(--color-success, #2a8a4a);
+}
+.image-list__copy .gg-copy {
+	transform: scale(0.55);
+	margin: 0 4px 0 -2px;
+}
 .image-list__title-edit {
 	margin-top: 0.25em;
 }

--- a/public/editor-assets/scripts/editor.js
+++ b/public/editor-assets/scripts/editor.js
@@ -170,6 +170,36 @@
 		copyToClipboard($(this).attr("rel"));
     });
 
+	// Image-list copy button: default copies the Markdown construct
+	// `![<title>](/uploads/<path>)`; Shift+Click copies just the path.
+	$(document).on("click", ".image-list__copy", function(e) {
+		e.preventDefault();
+		var btn = $(this);
+		var text = e.shiftKey
+			? btn.attr("data-copy-path")
+			: btn.attr("data-copy-md");
+		if (!text) { return; }
+		var afterCopy = function() {
+			var label = btn.find(".image-list__copy-label");
+			var original = label.text();
+			label.text(e.shiftKey ? "path copied" : "copied");
+			btn.addClass("is-copied");
+			setTimeout(function() {
+				label.text(original);
+				btn.removeClass("is-copied");
+			}, 1200);
+		};
+		if (navigator.clipboard && navigator.clipboard.writeText) {
+			navigator.clipboard.writeText(text).then(afterCopy, function() {
+				copyToClipboard(text);
+				afterCopy();
+			});
+		} else {
+			copyToClipboard(text);
+			afterCopy();
+		}
+	});
+
 	$("#page-list-table tbody").sortable({
 		helper: fixWidthHelper,
 		items:"tr.sortable",


### PR DESCRIPTION
Each uploaded image in the Page-Edit form now carries a small copy button next to the filename. A plain click copies the full Markdown `![<title>](/uploads/<path>)`; Shift+Click copies just the path. The button briefly swaps its label to "copied" / "path copied" for visual confirmation.

The button uses `navigator.clipboard.writeText` where available and falls back to the existing execCommand helper otherwise. The alt text inside the Markdown is taken from the file's `title` (caption) field, leaving an empty alt when no caption is set.