### PR TITLE
chore(basic-theme): drop IS_IM guard from template files

### DIFF
--- a/themes/basic/blog-post.php
+++ b/themes/basic/blog-post.php
@@ -1,4 +1,3 @@
-<?php defined('IS_IM') or die('You cannot access this page directly'); ?>
 <?php include 'resources/chunks/_head.php' ?>
 <body>
 <main role="main" class="default">

--- a/themes/basic/blog.php
+++ b/themes/basic/blog.php
@@ -1,4 +1,3 @@
-<?php defined('IS_IM') or die('You cannot access this page directly'); ?>
 <?php include 'resources/chunks/_head.php' ?>
 <body>
 <main role="main" class="blog">

--- a/themes/basic/contact.php
+++ b/themes/basic/contact.php
@@ -1,4 +1,3 @@
-<?php defined('IS_IM') or die('You cannot access this page directly'); ?>
 <?php include 'resources/chunks/_head.php' ?>
 <body>
 <main role="main" class="default">

--- a/themes/basic/default.php
+++ b/themes/basic/default.php
@@ -1,4 +1,3 @@
-<?php defined('IS_IM') or die('You cannot access this page directly'); ?>
 <?php include 'resources/chunks/_head.php' ?>
 <body>
 <main role="main" class="default">

--- a/themes/basic/resources/chunks/_header.php
+++ b/themes/basic/resources/chunks/_header.php
@@ -1,4 +1,3 @@
-<?php defined('IS_IM') or die('You cannot access this page directly'); ?>
 <header class="uk-container">
 	<nav class="uk-navbar uk-navbar-container uk-margin uk-navbar-transparent">
 		<div class="uk-navbar-left brand-wrapper">

--- a/themes/basic/resources/chunks/_sidebar-right.php
+++ b/themes/basic/resources/chunks/_sidebar-right.php
@@ -1,4 +1,3 @@
-<?php defined('IS_IM') or die('You cannot access this page directly'); ?>
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/themes/basic/template.php
+++ b/themes/basic/template.php
@@ -1,4 +1,4 @@
-<?php defined('IS_IM') or die('You cannot access this page directly'); 
+<?php
 
 $tplName = $site->sanitizer->templateName($site->currentTemplate());
 $tplFile = __DIR__."/$tplName.php";


### PR DESCRIPTION
The guard predates Scriptor's public/ webroot refactor and no longer protects anything: theme PHP files live outside the document root and are unreachable over HTTP. Removing it keeps the bundled theme minimal and avoids implying it is a security boundary that authors of new themes should copy.

7 files affected (template.php, blog.php, blog-post.php, contact.php, default.php, _header.php, _sidebar-right.php).