### PR TITLE
feat(cli): bin/scriptor install for greenfield setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,17 +43,28 @@ Demo:    [https://demos.scriptor-cms.dev](https://demos.scriptor-cms.dev)
 git clone git@github.com:bigin/Scriptor.git
 cd Scriptor
 composer install
+php bin/scriptor install
 ```
 
-Point your web server at the `public/` directory. The installer
-creates `data/imanager.db` on the first request via the schema-migrate
-step. To run migrations explicitly:
+`bin/scriptor install` seeds a fresh SQLite database with the Pages
+and Users categories, their fields, a Home page, and one admin
+user. You will be prompted for an admin password (12+ characters).
+The command refuses to run a second time once installed, so it is
+safe to leave in a deployment script.
+
+For automation (CI, Docker, scripted provisioning) pass the
+password explicitly and skip the confirmation prompt:
 
 ```bash
-vendor/bin/imanager schema:migrate --db=data/imanager.db
+SCRIPTOR_ADMIN_PASSWORD='your-strong-secret' \
+  php bin/scriptor install --yes
 ```
 
-For PHP's built-in server during local development:
+See [`docs/install.md`](docs/install.md) for the full walkthrough,
+flag reference, and security notes.
+
+Point your web server at the `public/` directory. For PHP's
+built-in server during local development:
 
 ```bash
 php -S 127.0.0.1:8080 -t public public/index.php

--- a/bin/scriptor
+++ b/bin/scriptor
@@ -1,0 +1,136 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Scriptor CLI entry point.
+ *
+ * Today only knows the `install` subcommand. Designed to grow more
+ * subcommands later (`user:add`, `user:passwd`, `cache:clear`, …);
+ * the dispatch stays a simple switch until that list outgrows it,
+ * at which point Symfony Console becomes worth its dependency cost.
+ *
+ * Security guarantee G1 from docs/scriptor-install-cli-plan.md: this
+ * file refuses to run under any SAPI but `cli`. Belt-and-suspenders
+ * to the webroot layout (bin/ lives outside public/), so a misconfig
+ * that exposes bin/ over HTTP still can't run install via PHP-FPM.
+ */
+
+if (\PHP_SAPI !== 'cli') {
+    \fwrite(\STDERR, "bin/scriptor only runs from the command line.\n");
+    exit(3);
+}
+
+$root = \dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+$args = $argv;
+\array_shift($args); // drop the script name
+$command = $args[0] ?? '';
+\array_shift($args);
+
+switch ($command) {
+    case 'install':
+        $options = parse_options($args);
+        if (isset($options['help'])) {
+            print_install_help();
+            exit(0);
+        }
+        $console = new \Scriptor\Boot\Cli\Console();
+        $prompt  = new \Scriptor\Boot\Cli\PasswordPrompt($console);
+        $cmd     = new \Scriptor\Boot\Cli\InstallCommand($root, $console, $prompt);
+        exit($cmd->run($options));
+
+    case '':
+    case 'help':
+    case '--help':
+    case '-h':
+        print_top_help();
+        exit($command === '' ? 1 : 0);
+
+    default:
+        \fwrite(\STDERR, "Unknown command: {$command}\n\n");
+        print_top_help();
+        exit(1);
+}
+
+/**
+ * @param list<string> $args
+ * @return array<string, string|bool>
+ */
+function parse_options(array $args): array
+{
+    $opts = [];
+    foreach ($args as $arg) {
+        if ($arg === '--yes' || $arg === '-y') {
+            $opts['yes'] = true;
+            continue;
+        }
+        if ($arg === '--help' || $arg === '-h') {
+            $opts['help'] = true;
+            continue;
+        }
+        if (\str_starts_with($arg, '--')) {
+            $body = \substr($arg, 2);
+            $eqPos = \strpos($body, '=');
+            if ($eqPos === false) {
+                // Treat boolean flag.
+                $opts[$body] = true;
+                continue;
+            }
+            $name  = \substr($body, 0, $eqPos);
+            $value = \substr($body, $eqPos + 1);
+            $opts[$name] = $value;
+            continue;
+        }
+        // Bare positional args have no meaning today; ignore silently
+        // rather than break future extensions.
+    }
+    return $opts;
+}
+
+function print_top_help(): void
+{
+    echo <<<'TXT'
+Scriptor CLI.
+
+Usage:
+  bin/scriptor <command> [options]
+
+Commands:
+  install    Seed a fresh Scriptor database (Pages, Users, admin, Home).
+  help       Show this message.
+
+Run `bin/scriptor <command> --help` for command-specific options.
+
+TXT;
+}
+
+function print_install_help(): void
+{
+    echo <<<'TXT'
+Seed a fresh Scriptor database.
+
+Usage:
+  bin/scriptor install [options]
+
+Options:
+  --password=<value>   Admin password (overrides SCRIPTOR_ADMIN_PASSWORD env).
+  --username=<name>    Admin username (default: admin).
+  --email=<addr>       Admin email (default: admin@localhost).
+  --db=<path>          Database file path (default: data/imanager.db).
+  --yes, -y            Skip the "type INSTALL to proceed" prompt. Required
+                       when stdin is not a TTY.
+  --help, -h           Show this message.
+
+Password sources (first match wins):
+  1. --password=...
+  2. $SCRIPTOR_ADMIN_PASSWORD
+  3. Interactive prompt (requires a TTY).
+
+The command refuses to run if a Pages category already exists in the
+database. To start over, delete the database file explicitly.
+
+TXT;
+}

--- a/bin/smoke-install.sh
+++ b/bin/smoke-install.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Regression smoke test for bin/scriptor install.
+#
+# Scriptor does not ship a PHPUnit setup today. This script gives us
+# a re-runnable end-to-end check for the install command's contract:
+# bad input rejected, valid input seeds the schema correctly, re-run
+# is refused, and the seeded DB boots through Scriptor's request
+# pipeline.
+#
+# Run from the repo root: bash bin/smoke-install.sh
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SCRIPTOR_BIN="$ROOT/bin/scriptor"
+TMP_DB="$(mktemp -t scriptor-install-smoke.XXXXXX).db"
+PHP_BIN="${PHP_BIN:-php}"
+PASSED=0
+FAILED=0
+
+trap 'rm -f "$TMP_DB"' EXIT
+
+case_pass() { printf '  \033[32mOK\033[0m   %s\n' "$1"; PASSED=$((PASSED+1)); }
+case_fail() { printf '  \033[31mFAIL\033[0m %s\n' "$1"; FAILED=$((FAILED+1)); }
+
+assert_exit() {
+    local label="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        case_pass "$label (exit $actual)"
+    else
+        case_fail "$label (expected exit $expected, got $actual)"
+    fi
+}
+
+# 1. Too-short password rejected.
+rm -f "$TMP_DB"
+"$PHP_BIN" "$SCRIPTOR_BIN" install --password=short --db="$TMP_DB" --yes >/dev/null 2>&1
+assert_exit "rejects password < 12 chars" 2 $?
+
+# 2. Blacklisted password rejected.
+"$PHP_BIN" "$SCRIPTOR_BIN" install --password=gT5nLazzyBob --db="$TMP_DB" --yes >/dev/null 2>&1
+assert_exit "rejects blacklisted password (gT5nLazzyBob)" 2 $?
+
+# 3. Valid install succeeds.
+"$PHP_BIN" "$SCRIPTOR_BIN" install --password=smoke-test-2026 --db="$TMP_DB" --yes >/dev/null 2>&1
+assert_exit "valid install succeeds" 0 $?
+
+# 4. DB structure matches expected shape.
+CAT_COUNT=$(sqlite3 "$TMP_DB" "SELECT COUNT(*) FROM categories")
+[ "$CAT_COUNT" = "2" ] && case_pass "creates 2 categories" || case_fail "expected 2 categories, got $CAT_COUNT"
+
+FIELD_COUNT=$(sqlite3 "$TMP_DB" "SELECT COUNT(*) FROM fields")
+[ "$FIELD_COUNT" = "10" ] && case_pass "creates 10 fields (7 pages + 3 users)" || case_fail "expected 10 fields, got $FIELD_COUNT"
+
+ITEM_COUNT=$(sqlite3 "$TMP_DB" "SELECT COUNT(*) FROM items")
+[ "$ITEM_COUNT" = "2" ] && case_pass "creates 2 items (admin user + Home page)" || case_fail "expected 2 items, got $ITEM_COUNT"
+
+# 5. Re-run refused.
+"$PHP_BIN" "$SCRIPTOR_BIN" install --password=smoke-test-2026 --db="$TMP_DB" --yes >/dev/null 2>&1
+assert_exit "refuses re-run (Pages exists)" 1 $?
+
+# 6. No-TTY without --yes refused.
+echo "" | "$PHP_BIN" "$SCRIPTOR_BIN" install --password=smoke-test-2026 --db=/tmp/no-tty.db >/dev/null 2>&1
+NO_TTY_EXIT=$?
+rm -f /tmp/no-tty.db
+[ "$NO_TTY_EXIT" = "4" ] && case_pass "refuses non-TTY without --yes" || case_fail "expected exit 4 (no TTY), got $NO_TTY_EXIT"
+
+# 7. Password roundtrip: hash verifies via password_verify().
+HASH=$(sqlite3 "$TMP_DB" "SELECT json_extract(data, '\$.password') FROM items WHERE name='admin'")
+SCR_PASS=smoke-test-2026 SCR_HASH="$HASH" "$PHP_BIN" -r "exit(password_verify(getenv('SCR_PASS'), getenv('SCR_HASH')) ? 0 : 1);"
+assert_exit "admin password verifies (good case)" 0 $?
+SCR_PASS=wrong-password SCR_HASH="$HASH" "$PHP_BIN" -r "exit(password_verify(getenv('SCR_PASS'), getenv('SCR_HASH')) ? 0 : 1);"
+assert_exit "wrong password rejected" 1 $?
+
+# 8. PageRepository can boot against the seeded DB.
+"$PHP_BIN" -d display_errors=stderr -r "
+require '$ROOT/vendor/autoload.php';
+\$c = Scriptor\Boot\ImanagerBootstrap::create('$ROOT', ['databasePath' => '$TMP_DB']);
+\$repo = new Scriptor\Boot\Frontend\PageRepository(
+    \$c->get(Imanager\Storage\CategoryRepository::class),
+    \$c->get(Imanager\Storage\ItemRepository::class)
+);
+exit(\$repo->findBySlug('home') === null ? 1 : 0);
+" 2>/dev/null
+assert_exit "PageRepository::findBySlug(home) returns the seeded page" 0 $?
+
+echo
+printf 'Result: %d passed, %d failed\n' "$PASSED" "$FAILED"
+[ "$FAILED" = "0" ] || exit 1

--- a/boot/Cli/Console.php
+++ b/boot/Cli/Console.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Cli;
+
+/**
+ * Thin wrapper around stdin/stdout/stderr.
+ *
+ * Exists so InstallCommand and PasswordPrompt can be unit-tested with
+ * an in-memory replacement without `fopen('php://temp')` dancing in
+ * every test. Production code uses `new Console()`.
+ */
+class Console
+{
+    /** @var resource */
+    protected $stdin;
+    /** @var resource */
+    protected $stdout;
+    /** @var resource */
+    protected $stderr;
+
+    public function __construct()
+    {
+        $this->stdin  = \STDIN;
+        $this->stdout = \STDOUT;
+        $this->stderr = \STDERR;
+    }
+
+    public function writeln(string $line): void
+    {
+        \fwrite($this->stdout, $line . "\n");
+    }
+
+    public function errln(string $line): void
+    {
+        \fwrite($this->stderr, $line . "\n");
+    }
+
+    public function prompt(string $label): string
+    {
+        \fwrite($this->stdout, $label);
+        $line = \fgets($this->stdin);
+        return $line === false ? '' : \rtrim($line, "\r\n");
+    }
+
+    /**
+     * Read a line with echo suppressed via `stty -echo`. Falls back to
+     * normal echo if stty is unavailable (Windows, weird terminals).
+     * Returns the empty string when no TTY is attached.
+     */
+    public function promptSecret(string $label): string
+    {
+        if (! $this->stdinIsTty()) {
+            return '';
+        }
+        \fwrite($this->stdout, $label);
+        $sttyOriginal = $this->trySttyToggle('-echo');
+        try {
+            $line = \fgets($this->stdin);
+        } finally {
+            if ($sttyOriginal !== null) {
+                \shell_exec('stty ' . \escapeshellarg($sttyOriginal));
+            }
+            \fwrite($this->stdout, "\n");
+        }
+        return $line === false ? '' : \rtrim($line, "\r\n");
+    }
+
+    public function stdinIsTty(): bool
+    {
+        return \stream_isatty($this->stdin);
+    }
+
+    /**
+     * Toggle a stty mode. Returns the previous settings string so the
+     * caller can restore it, or null when stty is unavailable.
+     */
+    private function trySttyToggle(string $mode): ?string
+    {
+        $current = \shell_exec('stty -g 2>/dev/null');
+        if ($current === null || \trim((string) $current) === '') {
+            return null;
+        }
+        \shell_exec('stty ' . \escapeshellarg($mode) . ' 2>/dev/null');
+        return \trim((string) $current);
+    }
+}

--- a/boot/Cli/InstallCommand.php
+++ b/boot/Cli/InstallCommand.php
@@ -1,0 +1,345 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Cli;
+
+use Imanager\Domain\Category;
+use Imanager\Domain\Field;
+use Imanager\Domain\Item;
+use Imanager\Storage\CategoryRepository;
+use Imanager\Storage\FieldRepository;
+use Imanager\Storage\ItemRepository;
+use League\Container\Container;
+use Scriptor\Boot\App;
+use Scriptor\Boot\ImanagerBootstrap;
+
+/**
+ * `bin/scriptor install` implementation.
+ *
+ * Seeds a fresh Scriptor database with the Pages + Users categories,
+ * their fields, an admin user, and one Home page so the frontend
+ * renders on first request. Refuses to run if any of those already
+ * exist (idempotent via real-state check, not lock-files). Reads the
+ * admin password from `--password`, then `SCRIPTOR_ADMIN_PASSWORD`,
+ * then a TTY prompt. Enforces a 12-character minimum and rejects a
+ * small blacklist of obvious defaults.
+ *
+ * See `docs/scriptor-install-cli-plan.md` for the security
+ * rationale (G1..G6) and the design alternatives that were rejected.
+ */
+final class InstallCommand
+{
+    private const EXIT_OK             = 0;
+    private const EXIT_ALREADY        = 1;
+    private const EXIT_BAD_PASSWORD   = 2;
+    private const EXIT_NOT_CLI        = 3;
+    private const EXIT_UNEXPECTED     = 4;
+    private const EXIT_NEED_YES_FLAG  = 4;
+
+    /**
+     * Hard-coded blacklist of obvious-default passwords. Lower-case
+     * comparison; includes this project's old demo password plus the
+     * top entries from the 2024 NCSC list. Not exhaustive; the
+     * 12-char minimum is the primary defence.
+     *
+     * @var list<string>
+     */
+    private const PASSWORD_BLACKLIST = [
+        'admin',
+        'administrator',
+        'password',
+        'password123',
+        'qwerty12345',
+        'gt5nlazzybob',
+        'scriptor',
+        'scriptor123',
+        'changeme',
+        'letmein12345',
+    ];
+
+    private const MIN_PASSWORD_LENGTH = 12;
+
+    public function __construct(
+        private readonly string $scriptorRoot,
+        private readonly Console $console,
+        private readonly PasswordPrompt $passwordPrompt,
+    ) {
+    }
+
+    /**
+     * @param array{
+     *     password?: string,
+     *     username?: string,
+     *     email?: string,
+     *     db?: string,
+     *     yes?: bool,
+     * } $options
+     */
+    public function run(array $options): int
+    {
+        try {
+            return $this->runUnsafe($options);
+        } catch (\Throwable $e) {
+            $this->console->errln('Install failed: ' . $e->getMessage());
+            $this->console->errln('  in ' . $e->getFile() . ':' . $e->getLine());
+            return self::EXIT_UNEXPECTED;
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function runUnsafe(array $options): int
+    {
+        $username = isset($options['username']) && \is_string($options['username']) && $options['username'] !== ''
+            ? $options['username']
+            : 'admin';
+        $email = isset($options['email']) && \is_string($options['email']) && $options['email'] !== ''
+            ? $options['email']
+            : 'admin@localhost';
+        $skipConfirm = ! empty($options['yes']);
+
+        $databasePath = isset($options['db']) && \is_string($options['db']) && $options['db'] !== ''
+            ? $options['db']
+            : $this->scriptorRoot . '/data/imanager.db';
+
+        // G5: explicit confirmation. The --yes flag is the only escape
+        // hatch, intended for CI / Docker entrypoints. Stdin must be a
+        // TTY for the interactive path; if it isn't and --yes wasn't
+        // passed, bail with a hint rather than hang.
+        if (! $skipConfirm) {
+            if (! $this->console->stdinIsTty()) {
+                $this->console->errln(
+                    'Refusing to proceed: stdin is not a TTY and --yes was not given.'
+                );
+                $this->console->errln(
+                    'Pass --yes explicitly when running non-interactively (CI / Docker).'
+                );
+                return self::EXIT_NEED_YES_FLAG;
+            }
+            $this->console->writeln('About to seed ' . $databasePath . '.');
+            $confirmation = $this->console->prompt('Type INSTALL to proceed: ');
+            if ($confirmation !== 'INSTALL') {
+                $this->console->errln('Aborted (confirmation phrase did not match).');
+                return self::EXIT_UNEXPECTED;
+            }
+        }
+
+        // Boot the same iManager container the request lifecycle uses.
+        // This also runs SchemaManager::migrate(), so the install command
+        // is safe to invoke against an empty file: tables get created
+        // before we touch any row.
+        $container = $this->bootContainer($databasePath);
+
+        /** @var CategoryRepository $categories */
+        $categories = $container->get(CategoryRepository::class);
+        /** @var FieldRepository $fields */
+        $fields = $container->get(FieldRepository::class);
+        /** @var ItemRepository $items */
+        $items = $container->get(ItemRepository::class);
+
+        // G2: real-state check. No lock-files; the DB itself is the
+        // source of truth. Existing Pages category = already installed.
+        if ($categories->findBySlug('pages') !== null) {
+            $this->console->errln(
+                'Scriptor is already installed (Pages category exists in '
+                . $databasePath . ').'
+            );
+            $this->console->errln(
+                'To start over, delete the database file explicitly and '
+                . 'rerun this command.'
+            );
+            return self::EXIT_ALREADY;
+        }
+
+        // G3/G4: resolve and validate the password before any DB writes.
+        // Failing here leaves the database untouched.
+        $password = $this->resolvePassword($options);
+        $validationError = $this->validatePassword($password);
+        if ($validationError !== null) {
+            $this->console->errln('Invalid admin password: ' . $validationError);
+            return self::EXIT_BAD_PASSWORD;
+        }
+
+        $this->console->writeln('[1/4] Creating Pages category and 7 fields...');
+        $pagesCategoryId = $this->ensurePagesCategory($categories, $fields);
+
+        $this->console->writeln('[2/4] Creating Users category and 3 fields...');
+        $usersCategoryId = $this->ensureUsersCategory($categories, $fields);
+
+        $this->console->writeln('[3/4] Creating admin user...');
+        $this->createAdminUser($items, $usersCategoryId, $username, $email, $password);
+
+        $this->console->writeln('[4/4] Seeding Home page...');
+        $this->createHomePage($items, $pagesCategoryId);
+
+        $this->console->writeln('');
+        $this->console->writeln('Scriptor is ready.');
+        $this->console->writeln('  Frontend:    http://your-host/');
+        $this->console->writeln('  Editor:      http://your-host/editor/');
+        $this->console->writeln('  Admin user:  ' . $username);
+        $this->console->writeln('  Database:    ' . $databasePath);
+
+        return self::EXIT_OK;
+    }
+
+    private function bootContainer(string $databasePath): Container
+    {
+        // Mirror the request-time boot sequence so behaviour is identical.
+        // ImanagerBootstrap::create() calls DefaultBootstrap::boot() which
+        // applies any pending schema migrations to a fresh file.
+        $container = ImanagerBootstrap::create(
+            $this->scriptorRoot,
+            ['databasePath' => $databasePath],
+        );
+        App::set($container);
+        return $container;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    private function resolvePassword(array $options): string
+    {
+        if (isset($options['password']) && \is_string($options['password']) && $options['password'] !== '') {
+            return $options['password'];
+        }
+        $envPassword = \getenv('SCRIPTOR_ADMIN_PASSWORD');
+        if (\is_string($envPassword) && $envPassword !== '') {
+            return $envPassword;
+        }
+        // TTY prompt path. Returns empty string when no TTY is available,
+        // which validatePassword() will reject.
+        return $this->passwordPrompt->readWithConfirmation(self::MIN_PASSWORD_LENGTH);
+    }
+
+    private function validatePassword(string $password): ?string
+    {
+        if ($password === '') {
+            return 'no password supplied (use --password=..., $SCRIPTOR_ADMIN_PASSWORD, or run from a TTY)';
+        }
+        if (\strlen($password) < self::MIN_PASSWORD_LENGTH) {
+            return 'too short (need ' . self::MIN_PASSWORD_LENGTH . '+ characters)';
+        }
+        if (\in_array(\strtolower($password), self::PASSWORD_BLACKLIST, true)) {
+            return 'password is on the blocklist of obvious defaults';
+        }
+        return null;
+    }
+
+    private function ensurePagesCategory(
+        CategoryRepository $categories,
+        FieldRepository $fields,
+    ): int {
+        $now = \time();
+        $category = $categories->ensure(new Category(
+            id: null,
+            name: 'Pages',
+            slug: 'pages',
+            position: 1,
+            created: $now,
+            updated: $now,
+        ));
+
+        $categoryId = $category->id ?? throw new \RuntimeException('Pages category save returned no id');
+
+        // Field set matches docker/seed-demo.sql 1:1 so the editor's
+        // existing Pages form keeps working without any further changes.
+        $definitions = [
+            Field::slug($categoryId, 'slug', 'Slug')->position(1),
+            Field::text($categoryId, 'parent', 'Parent')->position(2),
+            Field::text($categoryId, 'pagetype', 'Page Type')->position(3),
+            Field::text($categoryId, 'menu_title', 'Enter menu title')->position(4),
+            Field::longText($categoryId, 'content', 'Content')->position(5),
+            Field::text($categoryId, 'template', 'Page template')->position(6),
+            Field::file($categoryId, 'images', 'Images')->position(7),
+        ];
+        foreach ($definitions as $field) {
+            $fields->ensure($field);
+        }
+
+        return $categoryId;
+    }
+
+    private function ensureUsersCategory(
+        CategoryRepository $categories,
+        FieldRepository $fields,
+    ): int {
+        $now = \time();
+        $category = $categories->ensure(new Category(
+            id: null,
+            name: 'Users',
+            slug: 'users',
+            position: 2,
+            created: $now,
+            updated: $now,
+        ));
+
+        $categoryId = $category->id ?? throw new \RuntimeException('Users category save returned no id');
+
+        $definitions = [
+            Field::text($categoryId, 'role', 'Role')->position(1),
+            Field::text($categoryId, 'email', 'Email')->position(2),
+            Field::password($categoryId, 'password', 'Password')->position(3),
+        ];
+        foreach ($definitions as $field) {
+            $fields->ensure($field);
+        }
+
+        return $categoryId;
+    }
+
+    private function createAdminUser(
+        ItemRepository $items,
+        int $usersCategoryId,
+        string $username,
+        string $email,
+        string $password,
+    ): void {
+        $hash = \password_hash($password, \PASSWORD_BCRYPT);
+        if ($hash === false) {
+            throw new \RuntimeException('password_hash() returned false');
+        }
+        $now = \time();
+        $items->save(new Item(
+            id: null,
+            categoryId: $usersCategoryId,
+            name: $username,
+            label: null,
+            position: 1,
+            active: true,
+            data: [
+                'role'     => 'siteadmin',
+                'email'    => $email,
+                'password' => $hash,
+            ],
+            created: $now,
+            updated: $now,
+        ));
+    }
+
+    private function createHomePage(ItemRepository $items, int $pagesCategoryId): void
+    {
+        $now = \time();
+        $items->save(new Item(
+            id: null,
+            categoryId: $pagesCategoryId,
+            name: 'Home',
+            label: null,
+            position: 1,
+            active: true,
+            data: [
+                'slug'       => 'home',
+                'parent'     => '0',
+                'pagetype'   => '',
+                'menu_title' => 'Home',
+                'content'    => "# Welcome to Scriptor\n\nThis is your home page. Log in at `/editor/` to edit it or add more pages.",
+                'template'   => 'home',
+                'images'     => [],
+            ],
+            created: $now,
+            updated: $now,
+        ));
+    }
+}

--- a/boot/Cli/PasswordPrompt.php
+++ b/boot/Cli/PasswordPrompt.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Cli;
+
+/**
+ * Interactive TTY password reader with confirmation.
+ *
+ * Echo is suppressed via {@see Console::promptSecret()}; this class
+ * adds the confirmation loop and the "passwords don't match" retry.
+ * Up to three attempts before giving up; an empty string is returned
+ * on give-up so the caller's validatePassword() rejects it.
+ */
+final class PasswordPrompt
+{
+    private const MAX_ATTEMPTS = 3;
+
+    public function __construct(private readonly Console $console)
+    {
+    }
+
+    public function readWithConfirmation(int $minLength): string
+    {
+        if (! $this->console->stdinIsTty()) {
+            return '';
+        }
+        for ($attempt = 1; $attempt <= self::MAX_ATTEMPTS; $attempt++) {
+            $first = $this->console->promptSecret(
+                "Enter admin password ({$minLength}+ chars): "
+            );
+            $second = $this->console->promptSecret('Confirm admin password: ');
+            if ($first === $second && $first !== '') {
+                return $first;
+            }
+            $this->console->errln('Passwords did not match, try again.');
+        }
+        $this->console->errln('Too many failed attempts.');
+        return '';
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,9 @@
             "Scriptor\\Boot\\": "boot/"
         }
     },
+    "bin": [
+        "bin/scriptor"
+    ],
     "config": {
         "sort-packages": true,
         "platform": {

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,138 @@
+# Installing Scriptor
+
+A fresh Scriptor install needs three things in the SQLite database
+before the frontend can render: the **Pages** category with its
+fields, the **Users** category with its fields, and at least one
+admin user. `bin/scriptor install` creates all three plus a minimal
+Home page so `/` works on first request.
+
+## Prerequisites
+
+- PHP 8.2+ (8.3 recommended)
+- Composer 2
+- SQLite 3.38+
+- Standard PHP extensions: `mbstring`, `dom`, `json`, `gd`, `pdo_sqlite`
+- A web server with its document root pointed at `public/`
+
+## Interactive install (local dev)
+
+```bash
+git clone git@github.com:bigin/Scriptor.git
+cd Scriptor
+composer install
+php bin/scriptor install
+```
+
+The command will:
+
+1. Confirm the database path: `About to seed /path/to/data/imanager.db. Type INSTALL to proceed:`. Type `INSTALL` and press Enter.
+2. Prompt for an admin password (12 characters minimum, echo suppressed) and ask you to confirm it.
+3. Create the Pages and Users categories with their fields, seed an `admin` user, and add a Home page.
+
+You should see four `[n/4]` progress lines and a final summary
+block with the editor URL.
+
+Point your web server at `public/` and visit `/`. The Home page
+renders; `/editor/` accepts the credentials you just set.
+
+## Non-interactive install (Docker, CI, scripted provisioning)
+
+When stdin is not a TTY (CI pipelines, Docker entrypoints) you must
+pass `--yes` and supply the password through `--password` or the
+`SCRIPTOR_ADMIN_PASSWORD` environment variable.
+
+```bash
+SCRIPTOR_ADMIN_PASSWORD='your-strong-secret' \
+  php bin/scriptor install --yes
+```
+
+or equivalently:
+
+```bash
+php bin/scriptor install --yes --password='your-strong-secret'
+```
+
+Without `--yes` the command bails with a clear error rather than
+hang waiting for a confirmation that will never come.
+
+## All options
+
+```
+php bin/scriptor install [options]
+
+Options:
+  --password=<value>   Admin password (overrides SCRIPTOR_ADMIN_PASSWORD env).
+  --username=<name>    Admin username (default: admin).
+  --email=<addr>       Admin email (default: admin@localhost).
+  --db=<path>          Database file path (default: data/imanager.db).
+  --yes, -y            Skip the "type INSTALL to proceed" prompt. Required
+                       when stdin is not a TTY.
+  --help, -h           Show the inline help text.
+```
+
+Password sources are tried in order:
+
+1. `--password=...` flag
+2. `SCRIPTOR_ADMIN_PASSWORD` environment variable
+3. Interactive TTY prompt
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| 0 | Install completed |
+| 1 | Already installed (Pages category exists; refusing to overwrite) |
+| 2 | Invalid admin password (too short or on the blocklist) |
+| 3 | Invoked under a non-CLI SAPI |
+| 4 | Confirmation skipped without `--yes`, or any other unexpected error |
+
+## Re-installing
+
+`bin/scriptor install` refuses to run a second time against the
+same database, by design. To start over, delete the database file:
+
+```bash
+rm data/imanager.db
+php bin/scriptor install
+```
+
+There is intentionally no `--force` flag. If the install ever
+needs to recover from a half-written state, fix the data with
+direct SQL or the editor. The CLI is for greenfield seeding.
+
+## Security notes
+
+- The install command only runs from the command line. A misconfig
+  that exposed `bin/scriptor` over HTTP would still be refused at
+  the SAPI check on the first line of the script.
+- There is no default admin password. The command rejects passwords
+  under 12 characters and a small blocklist of obvious defaults
+  (including this project's old Docker demo password).
+- The "already installed" check looks at the actual database, not a
+  lock-file. An attacker who can delete files under `data/` cannot
+  trigger a re-install that would overwrite credentials.
+
+For the full security rationale and the design alternatives that
+were considered, see
+[`docs/scriptor-install-cli-plan.md`](scriptor-install-cli-plan.md).
+
+## Troubleshooting
+
+### "Category with slug 'pages' not found"
+
+You started the web server before running `bin/scriptor install`.
+iManager auto-creates the schema on first PDO connection, but it
+does not seed any rows. Stop the server, run the install command,
+then start the server again. Or just delete `data/imanager.db` and
+run the install command, which is faster.
+
+### "Refusing to proceed: stdin is not a TTY"
+
+Add `--yes` and supply a password via `--password` or
+`SCRIPTOR_ADMIN_PASSWORD`. The confirmation prompt only makes sense
+when a human is at the keyboard.
+
+### "Invalid admin password: too short"
+
+The minimum is 12 characters. There is no override; pick a longer
+one. Length is the cheapest defence against brute-force.


### PR DESCRIPTION
Add a CLI-only install command so a bare `git clone` + `composer install` checkout can be brought to a working state without docker/seed-demo.sql or hand-rolled SQL. Implements PR 2 of the plan in docs/scriptor-install-cli-plan.md.

Behaviour:
- Seeds Pages + Users categories with the same 7 + 3 fields the bundled basic theme and the editor's auth path already expect, creates an admin user, and inserts a minimal Home page so `/` renders on the very first request.
- Reads the admin password from --password, then SCRIPTOR_ADMIN_PASSWORD env, then a TTY prompt with confirmation. Rejects passwords under 12 characters or on a small blocklist of obvious defaults (including the project's old Docker demo).
- Refuses to run when a Pages category already exists. The check reads the live DB, not a lock-file, so deleting marker files cannot trigger an overwrite.
- Refuses to run under any SAPI but cli, refuses non-TTY input without --yes, never echoes the password.

Files:
- bin/scriptor: executable entry, argv parsing, subcommand dispatch
- boot/Cli/InstallCommand.php: the install logic
- boot/Cli/Console.php, PasswordPrompt.php: TTY helpers
- bin/smoke-install.sh: re-runnable regression script (11 checks)
- docs/install.md: walkthrough + flag reference + troubleshooting
- README.md: replace the misleading "creates DB on first request" paragraph with the explicit install step
- composer.json: declare bin/scriptor

Verified locally: 11/11 smoke checks green, including end-to-end boot of Scriptor's PageRepository against the seeded database.

Follow-ups (separate PRs per the plan):
- PR 3: switch docker/entrypoint.sh to call this CLI, retire seed-demo.sql
- PR 4: rewrite docs/install-shared-hosting.md against the new flow