### PR TITLE
docs(demo): align with bin/scriptor install + retired seed-demo.sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`bin/scriptor install` CLI** for greenfield setup. Seeds the
+  Pages + Users categories, their fields, an admin user, and a
+  minimal Home page so `/` works on the first request. Replaces
+  the previous "creates the DB on the first request" behaviour
+  that only ran schema migrations and left the editor unreachable.
+  Password is read from `--password`, `SCRIPTOR_ADMIN_PASSWORD`
+  env, or an interactive TTY prompt (12-char minimum, small
+  blocklist of obvious defaults). Refuses to run when a Pages
+  category already exists, refuses to run under any SAPI but
+  `cli`. Documented in [`docs/install.md`](docs/install.md).
+- **`bin/smoke-install.sh`** regression script (11 end-to-end
+  checks) covering the install CLI's contracts.
+
+### Changed
+
+- **Docker demo entrypoint** seeds through the install CLI rather
+  than a single all-in-one `seed-demo.sql` dump. The remaining
+  content rows (Articles, Contact, Footer cluster) moved to
+  `docker/seed-demo-content.sql` as a small content overlay.
+  Admin password reads from `SCRIPTOR_ADMIN_PASSWORD` (default
+  `gT5nLazzyBob`, override via host env for a private demo).
+- **Build-a-Theme tutorial + shared-hosting guide** both call out
+  the new install step instead of stopping at `composer install`.
+
+### Removed
+
+- `docker/seed-demo.sql`. The schema half is recreated by
+  iManager's auto-migrate; the data half lives in the install CLI
+  (categories, fields, admin, Home) and the content overlay
+  (`docker/seed-demo-content.sql`) for the demo's extra pages.
+
 ## 2.0.1 (2026-05-17) — Dependency refresh + doc polish
 
 No changes to Scriptor's own source. Captures the current state of

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -146,28 +146,55 @@ recreation.
 | `docker/Dockerfile` | `php:8.3-fpm-alpine` + iManager extensions + opcache + composer install of the runtime deps from Packagist. |
 | `docker/Dockerfile.web` | `nginx:alpine` with `public/` baked in so SCRIPT_FILENAME paths resolve identically in both containers. |
 | `docker/nginx.conf` | Front-controller routing; serves `/uploads/` directly; blocks dotfiles + any stray non-`index.php` PHP. |
-| `docker/entrypoint.sh` | On every start: `schema:migrate` (idempotent). On first start (no DB): restore seed + extract uploads. |
-| `docker/seed-demo.sql` | Database snapshot: schema + every page, field, file row, FTS5 index. |
-| `docker/seed-demo-uploads.tar.gz` | `public/uploads/` snapshot for page images referenced by the dump. |
+| `docker/entrypoint.sh` | On every start: `schema:migrate` (idempotent). On first start (no DB): run `bin/scriptor install`, overlay the content seed, extract uploads. |
+| `docker/seed-demo-content.sql` | Content overlay: the seven extra demo pages (Articles, Contact, Footer Pages, …) that `bin/scriptor install` does not seed itself. IDs start at 3 to leave room for the admin and Home rows the install command creates. |
+| `docker/seed-demo-uploads.tar.gz` | `public/uploads/` snapshot for page images referenced by the content overlay. |
 | `docker-compose.yml` | Two-service stack on `http://localhost:8080`. |
 
 ---
 
 ## Refreshing the seed when scriptor.cms content evolves
 
-```bash
-# In a working copy connected to the canonical scriptor.cms DB:
-vendor/bin/imanager dump --db=data/imanager.db > docker/seed-demo.sql
+The content overlay is hand-curated, not auto-generated. `bin/scriptor
+install` already handles categories, fields, the admin user, and a
+Home placeholder, so the seed file only carries the *extra* demo
+pages plus the file metadata for the images they reference.
 
-# And the upload subdirs the dump references:
+Workflow when the canonical scriptor.cms content changes and the
+demo image should pick it up:
+
+```bash
+# 1. From a working copy connected to the canonical scriptor.cms DB,
+#    dump the demo page rows. The admin user (Users category) and the
+#    install-created Home (id=2) are skipped on purpose.
+sqlite3 data/imanager.db <<'SQL' > /tmp/items.sql
+.mode insert items
+SELECT * FROM items WHERE category_id = 1 AND name != 'Home';
+SQL
+
+# 2. Renumber IDs so they start at 3 (the install command takes 1
+#    for admin and 2 for Home). Update parent references inside each
+#    row's JSON `data` blob the same way. Compare against the current
+#    docker/seed-demo-content.sql to see the exact shape, then hand-
+#    edit until it matches.
+
+# 3. Same for items_fts and files (item_id references follow items).
+
+# 4. Tar the upload subdirs the overlay references:
 COPYFILE_DISABLE=1 tar --format=ustar -czf docker/seed-demo-uploads.tar.gz \
   -C public uploads/<referenced-subdirs>
 ```
 
-Referenced subdirs come from
+Referenced upload subdirs come from
 `SELECT DISTINCT substr(path, 1, instr(path, '/') - 1) FROM files;`
 on the canonical DB. Use `ustar` format so alpine busybox tar
 doesn't warn about pax extended headers.
+
+If you find yourself doing this often, write a `bin/scriptor
+demo:dump` command that does the renumbering programmatically and
+commit it instead of refining the workflow above. The doc reflects
+the current cadence (a refresh every few quarters), not a long-term
+target.
 
 ---
 
@@ -180,9 +207,10 @@ doesn't warn about pax extended headers.
   [iManager deployment guide](https://github.com/bigin/imanager/blob/main/docs/deployment.md)
   and write your own Dockerfile.
 - **Developing on Scriptor itself.** Use the local
-  `composer install` + ServBay / nginx / Caddy setup the
-  [README](../README.md) documents; the demo image ships frozen
-  code from a `docker build` snapshot.
+  `composer install` + `php bin/scriptor install` + ServBay / nginx
+  / Caddy setup the [README](../README.md) and
+  [`docs/install.md`](install.md) document; the demo image ships
+  frozen code from a `docker build` snapshot.
 - **Migrating real 1.x data.** Use
   [`vendor/bin/imanager migrate:from-v1`](https://github.com/bigin/imanager/blob/main/docs/migration-guide.md)
   against your real data dir, not against this demo's seed.


### PR DESCRIPTION
PR #94 retired docker/seed-demo.sql and switched the demo entrypoint to bin/scriptor install + a content overlay, but docs/demo.md still listed the old file in the image inventory and walked through the all-in-one `imanager dump` workflow for refreshing the seed. Three fixes:

- File table: replace the `docker/seed-demo.sql` row with `docker/seed-demo-content.sql` and explain it as a content overlay; update the entrypoint row to mention the install CLI.
- Refresh workflow: rewrite the section to reflect the new content-only seed shape (dump items where category=1 and name != 'Home', renumber to start at id=3, hand-edit). Flag the manual step as the current cadence rather than a long-term target.
- "Developing on Scriptor itself": add `php bin/scriptor install` next to `composer install` and cross-link to docs/install.md.

Also opens a CHANGELOG `## Unreleased` block bundling the four install-CLI PRs (#92, #93, #94, #95) under Added/Changed/Removed.