### PR TITLE
fix(cli): drop install password minimum from 12 to 8 chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
   the previous "creates the DB on the first request" behaviour
   that only ran schema migrations and left the editor unreachable.
   Password is read from `--password`, `SCRIPTOR_ADMIN_PASSWORD`
-  env, or an interactive TTY prompt (12-char minimum, small
-  blocklist of obvious defaults). Refuses to run when a Pages
+  env, or an interactive TTY prompt (8-char minimum to match
+  iManager's `PasswordFieldType`, small blocklist of obvious
+  defaults). Refuses to run when a Pages
   category already exists, refuses to run under any SAPI but
   `cli`. Documented in [`docs/install.md`](docs/install.md).
 - **`bin/smoke-install.sh`** regression script (11 end-to-end

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ php bin/scriptor install
 
 `bin/scriptor install` seeds a fresh SQLite database with the Pages
 and Users categories, their fields, a Home page, and one admin
-user. You will be prompted for an admin password (12+ characters).
+user. You will be prompted for an admin password (8+ characters).
 The command refuses to run a second time once installed, so it is
 safe to leave in a deployment script.
 

--- a/bin/smoke-install.sh
+++ b/bin/smoke-install.sh
@@ -36,7 +36,7 @@ assert_exit() {
 # 1. Too-short password rejected.
 rm -f "$TMP_DB"
 "$PHP_BIN" "$SCRIPTOR_BIN" install --password=short --db="$TMP_DB" --yes >/dev/null 2>&1
-assert_exit "rejects password < 12 chars" 2 $?
+assert_exit "rejects password < 8 chars" 2 $?
 
 # 2. Blacklisted password rejected.
 "$PHP_BIN" "$SCRIPTOR_BIN" install --password=letmein12345 --db="$TMP_DB" --yes >/dev/null 2>&1

--- a/boot/Cli/InstallCommand.php
+++ b/boot/Cli/InstallCommand.php
@@ -22,7 +22,7 @@ use Scriptor\Boot\ImanagerBootstrap;
  * renders on first request. Refuses to run if any of those already
  * exist (idempotent via real-state check, not lock-files). Reads the
  * admin password from `--password`, then `SCRIPTOR_ADMIN_PASSWORD`,
- * then a TTY prompt. Enforces a 12-character minimum and rejects a
+ * then a TTY prompt. Enforces an 8-character minimum and rejects a
  * small blacklist of obvious defaults.
  *
  * See `docs/scriptor-install-cli-plan.md` for the security
@@ -40,8 +40,10 @@ final class InstallCommand
     /**
      * Hard-coded blacklist of obvious-default passwords. Lower-case
      * comparison. Top entries from the 2024 NCSC list plus a couple
-     * of Scriptor-specific variants. Not exhaustive; the 12-char
-     * minimum is the primary defence.
+     * of Scriptor-specific variants. Not exhaustive; the editor's
+     * LoginAttempts rate-limiter is the real defence against brute
+     * force, the blocklist just catches the most obvious copy-paste
+     * defaults.
      *
      * The Docker demo's known password is intentionally *not* in this
      * list, so that the same install CLI can drive both the demo
@@ -63,7 +65,15 @@ final class InstallCommand
         'letmein12345',
     ];
 
-    private const MIN_PASSWORD_LENGTH = 12;
+    /**
+     * Same floor as `Imanager\Field\Types\PasswordFieldType::defaultConfig()`
+     * uses for the editor's password input. Keeping the two in sync avoids
+     * the awkward situation where the CLI accepts a password the editor's
+     * change-password form would reject (or vice versa). The editor also
+     * rate-limits failed logins via LoginAttempts, so 8 chars + lockout is
+     * the actual defence; the install CLI just enforces the same floor.
+     */
+    private const MIN_PASSWORD_LENGTH = 8;
 
     public function __construct(
         private readonly string $scriptorRoot,

--- a/docs/install.md
+++ b/docs/install.md
@@ -26,7 +26,7 @@ php bin/scriptor install
 The command will:
 
 1. Confirm the database path: `About to seed /path/to/data/imanager.db. Type INSTALL to proceed:`. Type `INSTALL` and press Enter.
-2. Prompt for an admin password (12 characters minimum, echo suppressed) and ask you to confirm it.
+2. Prompt for an admin password (8 characters minimum, echo suppressed) and ask you to confirm it. The minimum matches iManager's `PasswordFieldType` so the editor's change-password form accepts the same passwords.
 3. Create the Pages and Users categories with their fields, seed an `admin` user, and add a Home page.
 
 You should see four `[n/4]` progress lines and a final summary
@@ -106,8 +106,10 @@ direct SQL or the editor. The CLI is for greenfield seeding.
   that exposed `bin/scriptor` over HTTP would still be refused at
   the SAPI check on the first line of the script.
 - There is no default admin password. The command rejects passwords
-  under 12 characters and a small blocklist of obvious defaults
-  (including this project's old Docker demo password).
+  under 8 characters and a small blocklist of obvious defaults.
+  The editor's login flow rate-limits failed attempts via
+  `LoginAttempts`, so the 8-char floor plus lockout is the real
+  brute-force defence; the blocklist is a copy-paste catch.
 - The "already installed" check looks at the actual database, not a
   lock-file. An attacker who can delete files under `data/` cannot
   trigger a re-install that would overwrite credentials.
@@ -134,5 +136,7 @@ when a human is at the keyboard.
 
 ### "Invalid admin password: too short"
 
-The minimum is 12 characters. There is no override; pick a longer
-one. Length is the cheapest defence against brute-force.
+The minimum is 8 characters, matching iManager's
+`PasswordFieldType`. There is no override; pick a longer one.
+The editor's login rate-limiter is the real brute-force defence,
+but the floor stops the most obvious typos.


### PR DESCRIPTION
The 12-char floor in InstallCommand was stricter than the editor itself: iManager's PasswordFieldType uses minLength=8 in its defaultConfig(), so the CLI would happily reject a password the editor's own change-password form would accept. Aligning at 8.

The real brute-force defence on the editor is LoginAttempts' per-IP rate-limiter + lockout, not the CLI's input check. The length floor stops trivially-short typos and aligns the install CLI with the editor; the blocklist catches obvious copy-paste defaults. Both are floor-level, neither is meant to substitute for the rate-limiter.

Files updated:
- boot/Cli/InstallCommand.php: MIN_PASSWORD_LENGTH 12 -> 8 with docblock explaining the iManager alignment.
- bin/smoke-install.sh: test label updated (the input is still the 5-char "short" which is < 8 too, so the test still asserts rejection).
- README.md, docs/install.md, CHANGELOG.md Unreleased entry: 12 references swapped to 8 with one-line note about iManager parity.

The plan doc (docs/scriptor-install-cli-plan.md) is kept at 12 as a frozen design-time snapshot. This commit message is the audit trail for the post-merge revision.