### PR TITLE
fix(docker): use --update-no-dev for the SCRIPTOR_PLUGINS composer re…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -73,7 +73,7 @@ COPY . .
 ARG SCRIPTOR_PLUGINS=""
 RUN if [ -n "$SCRIPTOR_PLUGINS" ]; then \
         composer require $SCRIPTOR_PLUGINS \
-            --no-dev --no-interaction --prefer-dist --optimize-autoloader; \
+            --update-no-dev --no-interaction --prefer-dist --optimize-autoloader; \
     fi
 
 # Entrypoint runs as root so it can chown a freshly-attached volume,


### PR DESCRIPTION
…quire

`composer require` takes `--update-no-dev`, not the install-flavoured `--no-dev`. The build-arg branch added in chore/plugins-opt-in errored out as soon as anyone actually used it ("The "--no-dev" option does not exist"). Caught while wiring the cms-site override to opt back into bigins/scriptor-markdown-pages.