### PR TITLE
docs: document plugin install paths post chore/plugins-opt-in

### DIFF
--- a/boot/Editor/Plugins/PluginsModule.php
+++ b/boot/Editor/Plugins/PluginsModule.php
@@ -43,8 +43,10 @@ final class PluginsModule implements Module
         $this->editor->pageContent =
             '<h1>' . htmlspecialchars($this->t('plugins_menu'), \ENT_QUOTES) . '</h1>'
             . '<p>Read-only view of installed Scriptor plugins. '
-            . 'Install with <code>composer require</code>; disable by '
-            . 'adding the plugin FQCN to '
+            . 'Install with <code>composer require</code> (host installs) '
+            . 'or set <code>SCRIPTOR_PLUGINS</code> as a Docker build arg '
+            . 'and <code>up -d --build</code> (containerised installs); '
+            . 'disable by adding the plugin FQCN to '
             . '<code>$config[\'plugins\'][\'disabled\']</code> in '
             . '<code>data/settings/custom.scriptor-config.php</code>.</p>'
             . '<table class="plugins-list"><thead><tr>'

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -137,6 +137,16 @@ This split means `git pull && docker compose up -d --build`
 propagates code changes; the DB and uploads survive container
 recreation.
 
+The demo image ships **plugin-free** — every `vendor/bigins/*`
+package you see in the container came in through the default
+`composer.json`'s `require`. To add a plugin to the demo (e.g. to
+exercise the *Documentation* editor module from
+`bigins/scriptor-markdown-pages`), set a `SCRIPTOR_PLUGINS` build
+arg in a compose override and rebuild — see
+[`docs/install.md` → Installing plugins](install.md#installing-plugins)
+for the recipe. The cms-site (scriptor-cms.dev) is the
+production reference for this pattern.
+
 ---
 
 ## Files in this repo

--- a/docs/install.md
+++ b/docs/install.md
@@ -138,6 +138,66 @@ There is intentionally no `--force` flag. If the install ever
 needs to recover from a half-written state, fix the data with
 direct SQL or the editor. The CLI is for greenfield seeding.
 
+## Installing plugins
+
+A default Scriptor install ships with **zero plugins**. Plugins
+are Composer packages of `type: scriptor-plugin` that you add per
+install. Discovery is automatic: Scriptor scans
+`vendor/composer/installed.json` on every boot, so the next request
+picks the plugin up after the `composer require` completes.
+
+### Host install (local PHP, shared hosting)
+
+From the Scriptor root:
+
+```bash
+composer require bigins/scriptor-markdown-pages
+```
+
+The `repositories` block in Scriptor's `composer.json` already
+points Composer at the VCS sources for `bigins/*` plugins, so no
+extra setup is needed.
+
+### Docker
+
+Container filesystems are immutable below the volumes, so the
+Docker workflow is to **bake the plugin into the image** via a
+build arg in your compose override:
+
+```yaml
+services:
+  scriptor:
+    build:
+      args:
+        SCRIPTOR_PLUGINS: "bigins/scriptor-markdown-pages:^0.1"
+```
+
+Then `docker compose up -d --build`. Scriptor's Dockerfile runs
+`composer require $SCRIPTOR_PLUGINS` during image build, so the
+plugin lands in `vendor/` and survives every restart, recreation,
+or deploy.
+
+Multiple plugins go in the same arg as a space-separated list:
+
+```yaml
+SCRIPTOR_PLUGINS: "bigins/scriptor-markdown-pages:^0.1 vendor/other-plugin:^2"
+```
+
+> **Trap: `docker exec scriptor composer require ...`** Works
+> immediately because the discovery cache invalidates from
+> `installed.json` mtime, but the change lives in the running
+> container's layer and is wiped by the next
+> `docker compose down && up`. Use it for "does this plugin even
+> boot" probes; never as an install path for anything you want to
+> keep.
+
+### Disabling a plugin without uninstalling it
+
+Set `$config['plugins']['disabled'] = ['vendor/name']` in
+`data/settings/custom.scriptor-config.php`. The plugin stays in
+`vendor/` but `PluginManager` skips it. Useful when bisecting a
+suspected plugin bug without touching Composer.
+
 ## Security notes
 
 - The install command only runs from the command line. A misconfig


### PR DESCRIPTION
Scriptor #100 removed `bigins/scriptor-markdown-pages` from the default `require` and made plugins opt-in via either host `composer require` or the Docker `SCRIPTOR_PLUGINS` build arg, but none of the user-facing docs explained how to actually add a plugin afterwards. A reader following install.md or demo.md would end up wondering whether plugins still exist or how to get one in.

Three small additions, scoped per surface:

- **docs/install.md** gains an "Installing plugins" section between "Re-installing" and "Security notes". Covers the host path, the Docker build-arg path, multi-plugin syntax, the `disabled` config knob, and a callout on why `docker exec scriptor composer require ...` is fine for boot probes but wrong as an install path (gets wiped by `down && up`).
- **docs/demo.md** gains a paragraph in "What lives where" pointing out the demo image is plugin-free by design and cross-linking install.md for the build-arg recipe. Keeps demo.md focused on running and exploring rather than duplicating install instructions.
- **boot/Editor/Plugins/PluginsModule.php** updates the Read-only-view blurb so a sysop staring at an empty plugin table in the editor sees both install paths spelled out, not just `composer require` — which doesn't work as a one-liner inside a running container the way it does on shared hosting.