### PR TITLE
docs: cover plugin uninstall paths + editor blurb

### DIFF
--- a/boot/Editor/Plugins/PluginsModule.php
+++ b/boot/Editor/Plugins/PluginsModule.php
@@ -19,7 +19,8 @@ use Scriptor\Boot\Plugin\PluginManager;
  * surfaces each one contributes through the Plugin API.
  *
  * No write actions here. Plugins are managed through Composer
- * (`composer require <vendor>/<plugin>`) and disabled by listing their
+ * (`composer require` / `composer remove`, or the `SCRIPTOR_PLUGINS`
+ * build arg in Docker) and disabled without removal by listing their
  * FQCN in `$config['plugins']['disabled']`. The module exists so
  * operators can see what is loaded without scrolling through PHP code.
  */
@@ -46,7 +47,9 @@ final class PluginsModule implements Module
             . 'Install with <code>composer require</code> (host installs) '
             . 'or set <code>SCRIPTOR_PLUGINS</code> as a Docker build arg '
             . 'and <code>up -d --build</code> (containerised installs); '
-            . 'disable by adding the plugin FQCN to '
+            . 'uninstall via <code>composer remove</code> or by dropping '
+            . 'the plugin from <code>SCRIPTOR_PLUGINS</code> + rebuild; '
+            . 'disable without removing by adding the plugin FQCN to '
             . '<code>$config[\'plugins\'][\'disabled\']</code> in '
             . '<code>data/settings/custom.scriptor-config.php</code>.</p>'
             . '<table class="plugins-list"><thead><tr>'

--- a/docs/install.md
+++ b/docs/install.md
@@ -198,6 +198,38 @@ Set `$config['plugins']['disabled'] = ['vendor/name']` in
 `vendor/` but `PluginManager` skips it. Useful when bisecting a
 suspected plugin bug without touching Composer.
 
+### Uninstalling plugins
+
+Reverse of the install path you used.
+
+**Host install:**
+
+```bash
+composer remove bigins/scriptor-markdown-pages
+```
+
+The plugin disappears from `vendor/composer/installed.json`, the
+discovery cache invalidates on the next request, and the editor
+modules + nav items the plugin contributed are gone.
+
+**Docker:** drop the plugin from your `SCRIPTOR_PLUGINS` build arg
+in the compose override (or remove the whole arg block if it was
+the only plugin), then rebuild:
+
+```bash
+docker compose up -d --build
+```
+
+The new image is built without that `composer require` step, so
+the plugin never lands in `vendor/`.
+
+> **Plugin-owned data is not removed.** Content trees, settings,
+> uploads, or database rows the plugin manages stay where they
+> are. Check the plugin's README for its on-disk footprint and
+> delete those paths manually if you want a clean state. For
+> `bigins/scriptor-markdown-pages` that means the per-theme
+> `content/` directories with `_index.md` files.
+
 ## Security notes
 
 - The install command only runs from the command line. A misconfig


### PR DESCRIPTION
The plugins-opt-in docs (#102) only covered the install side. Add a symmetric "Uninstalling plugins" section after "Disabling a plugin without uninstalling it" in docs/install.md, walking the host (`composer remove`) and Docker (drop the spec from `SCRIPTOR_PLUGINS` + rebuild) paths and warning that plugin-owned data on disk stays put.

Extend the read-only blurb on /editor/plugins/ and the class docblock so the install / uninstall / disable triad reads symmetrically there too.