### PR TITLE
fix(profile): clear error + valid install default for admin email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,22 @@
   doc site. Now sites opt in explicitly. The cms-site picks the
   plugin back up via its own compose override.
 
+### Fixed
+
+- **Profile save no longer rejects the install-default email.** The
+  install CLI used to seed `admin@localhost`, which PHP's
+  `FILTER_VALIDATE_EMAIL` rejects (no TLD). The profile editor's
+  email sanitizer then refused to save any change against that
+  default, with the misleading "Please fill in all required fields"
+  message. Two changes: the install default is now
+  `admin@example.com` (IANA-reserved, passes the validator), and the
+  profile module distinguishes between empty fields and an
+  invalid-format email (new `profile_email_invalid` i18n key) so
+  the message points at the actual problem. Existing installs with
+  `admin@localhost` need to set a valid email once via the profile
+  form to clear the validation; the new error message tells them
+  exactly that.
+
 ## 2.0.1 (2026-05-17) — Dependency refresh + doc polish
 
 No changes to Scriptor's own source. Captures the current state of

--- a/bin/scriptor
+++ b/bin/scriptor
@@ -118,7 +118,7 @@ Usage:
 Options:
   --password=<value>   Admin password (overrides SCRIPTOR_ADMIN_PASSWORD env).
   --username=<name>    Admin username (default: admin).
-  --email=<addr>       Admin email (default: admin@localhost).
+  --email=<addr>       Admin email (default: admin@example.com).
   --db=<path>          Database file path (default: data/imanager.db).
   --yes, -y            Skip the "type INSTALL to proceed" prompt. Required
                        when stdin is not a TTY.

--- a/boot/Cli/InstallCommand.php
+++ b/boot/Cli/InstallCommand.php
@@ -112,7 +112,7 @@ final class InstallCommand
             : 'admin';
         $email = isset($options['email']) && \is_string($options['email']) && $options['email'] !== ''
             ? $options['email']
-            : 'admin@localhost';
+            : 'admin@example.com';
         $skipConfirm = ! empty($options['yes']);
 
         $databasePath = isset($options['db']) && \is_string($options['db']) && $options['db'] !== ''

--- a/boot/Editor/Profile/ProfileModule.php
+++ b/boot/Editor/Profile/ProfileModule.php
@@ -76,10 +76,16 @@ final class ProfileModule implements Module
             return;
         }
 
+        $rawEmail = trim($this->editor->input->postString('email'));
         $name  = $this->editor->sanitizer->text(str_replace('"', '', $this->editor->input->postString('username')));
-        $email = $this->editor->sanitizer->email($this->editor->input->postString('email'));
-        if ($name === '' || $email === null || $email === '') {
+        if ($name === '' || $rawEmail === '') {
             $this->editor->addMsg('error', $this->t('profile_incomplete'));
+            $this->renderEdit($currentId);
+            return;
+        }
+        $email = $this->editor->sanitizer->email($rawEmail);
+        if ($email === null) {
+            $this->editor->addMsg('error', $this->t('profile_email_invalid'));
             $this->renderEdit($currentId);
             return;
         }

--- a/docs/install.md
+++ b/docs/install.md
@@ -101,7 +101,7 @@ php bin/scriptor install [options]
 Options:
   --password=<value>   Admin password (overrides SCRIPTOR_ADMIN_PASSWORD env).
   --username=<name>    Admin username (default: admin).
-  --email=<addr>       Admin email (default: admin@localhost).
+  --email=<addr>       Admin email (default: admin@example.com).
   --db=<path>          Database file path (default: data/imanager.db).
   --yes, -y            Skip the "type INSTALL to proceed" prompt. Required
                        when stdin is not a TTY.

--- a/docs/scriptor-install-cli-plan.md
+++ b/docs/scriptor-install-cli-plan.md
@@ -182,7 +182,7 @@ php bin/scriptor install [options]
 Options:
   --password=<value>    Admin password. Overrides SCRIPTOR_ADMIN_PASSWORD env.
   --username=<name>     Admin username (default: admin).
-  --email=<addr>        Admin email (default: admin@localhost).
+  --email=<addr>        Admin email (default: admin@example.com).
   --yes                 Skip the "type INSTALL to proceed" confirmation.
                         Required when stdin is not a TTY (CI, Docker).
   --db=<path>           Override database path (default: data/imanager.db).

--- a/editor/lang/de_DE.php
+++ b/editor/lang/de_DE.php
@@ -44,6 +44,7 @@ $i18n = [
 	'successful_login' => 'Sie wurden erfolgreich eingeloggt.',
 	'successful_logout' => 'Sie wurden erfolgreich ausgeloggt.',
 	'profile_incomplete' => 'Bitte füllen Sie alle Pflichtfelder aus.',
+	'profile_email_invalid' => 'Die E-Mail-Adresse hat kein gültiges Format.',
 	'short_password' => 'Ihr Kennwort ist zu kurz, bitte geben Sie ein neues Kennwort mit einer Länge von mindestens 6 Zeichen ein.',
 	'error_password_comparison' => 'Ihr Kennwort und Kennwort-Wiederholung stimmen nicht überein.',
 	'profile_successful_saved' => 'Ihre Profildaten wurden erfolgreich gespeichert.',

--- a/editor/lang/en_US.php
+++ b/editor/lang/en_US.php
@@ -44,6 +44,7 @@ $i18n = [
 	'successful_login' => 'You have been successfully logged in.',
 	'successful_logout' => 'You have been successfully logged out.',
 	'profile_incomplete' => 'Please fill in all required fields.',
+	'profile_email_invalid' => 'The email address is not in a valid format.',
 	'short_password' => 'The password you specified is too short, please enter a new password with a length of at least 6 characters.',
 	'error_password_comparison' => 'Password does not match the confirm password.',
 	'profile_successful_saved' => 'Your profile data has been saved successfully.',


### PR DESCRIPTION
The install CLI seeded `admin@localhost` as the default admin email, but PHP's `FILTER_VALIDATE_EMAIL` rejects values without a TLD. The profile editor uses that same filter via iManager's `Sanitizer::email()`, so the seeded default could never be saved back: every profile save attempt produced "Please fill in all required fields" — a message that gave no hint about which field had failed or why.

Two changes:

1. **Install default is now `admin@example.com`** (IANA-reserved example domain, passes the validator). Touched `boot/Cli/InstallCommand.php`, `bin/scriptor` help text, `docs/install.md`, and the design plan doc.

2. **Profile module separates "missing field" from "invalid email format"** so the message points at the actual problem. Empty email still falls under `profile_incomplete`; a non-empty value that fails the sanitizer hits a new `profile_email_invalid` key (en + de).

Existing installs with `admin@localhost` need to set a valid email once via the profile form to clear the validation; the new error message now tells them exactly that.