### PR TITLE
docs(readme): stop presenting the Docker demo password as a universal…

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,9 @@ reset to factory state, and what the image is (and isn't) good for.
 https://your-website.com/editor/
 ```
 
-Default credentials (change them on first login):
-
-> User: `admin`  
-> Password: `gT5nLazzyBob`
+Sign in with the credentials you set during `bin/scriptor install`.
+For the bundled Docker demo the default is `admin / gT5nLazzyBob`
+(override via `SCRIPTOR_ADMIN_PASSWORD`).
 
 ## Performance
 


### PR DESCRIPTION
… default

The "Admin panel" section listed `admin / gT5nLazzyBob` as the default credentials, but that hasn't been universally true since `bin/scriptor install` landed: regular installs now prompt for a password (or take one via `--password` / `SCRIPTOR_ADMIN_PASSWORD`), and `gT5nLazzyBob` is only the demo password baked into the Docker entrypoint.

Replace the block with a sentence that points at the install command and calls out the Docker exception with its env override.