### PR TITLE
fix(frontend): render the addMsg() queue on $site->render('messages')

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,19 @@
 
 ### Fixed
 
+- **`$site->render('messages')` actually renders queued messages.**
+  The frontend `Site` had two properties, `array $msgs` (filled by
+  `addMsg()`) and `string $messages` (never assigned anywhere); the
+  `messages` render hook read the empty string. Themes that ran
+  `addMsg('success', '...')` after a successful POST got nothing on
+  screen. New `Site::renderMsgs()` mirrors the editor's helper
+  (`<ul class="messages"><li class="msg msg-{type}">...</li></ul>`),
+  drains `$msgs[]` on render, and `render('messages')` dispatches
+  through it. The dead `public string $messages` property is
+  removed; the bundled `basic` theme's `_sidebar-right.php` is
+  updated from `<?= $site->messages ?>` to
+  `<?= $site->render('messages') ?>` to match. Themes that read
+  `$site->messages` directly must migrate to `render('messages')`.
 - **Profile save no longer rejects the install-default email.** The
   install CLI used to seed `admin@localhost`, which PHP's
   `FILTER_VALIDATE_EMAIL` rejects (no TLD). The profile editor's

--- a/boot/Frontend/Site.php
+++ b/boot/Frontend/Site.php
@@ -25,10 +25,11 @@ use Scriptor\Boot\Events\Frontend\RouteNotFound;
  *
  * Holds the `$site` surface that bundled themes consume:
  *   - properties: `siteUrl`, `themeUrl`, `version`, `config`, `page`,
- *     `messages`, `urlSegments`, `input`, `sanitizer`, `pages`,
+ *     `urlSegments`, `input`, `sanitizer`, `pages`,
  *     `templateParser`, `cache`
  *   - rendering: `render($element)` with overridable hooks; theme
- *     subclasses override the `render*()` methods.
+ *     subclasses override the `render*()` methods. The `messages`
+ *     element renders the pending `$msgs[]` queue as HTML.
  *   - utilities: `getBasePath()`, `getPageUrl()`, `addMsg()`,
  *     `throw404()`, `getTCP()`, `templateName()`.
  *
@@ -41,7 +42,6 @@ class Site
     public string $themeUrl;
     public string $version = '2.0.0-dev';
     public ?Page $page = null;
-    public string $messages = '';
     public UrlSegments $urlSegments;
     public Request $input;
     public Sanitizer $sanitizer;
@@ -162,7 +162,7 @@ class Site
         return match ($element) {
             'content'    => $this->renderContent(),
             'navigation' => $this->renderNavigation(),
-            'messages'   => $this->messages,
+            'messages'   => $this->renderMsgs(),
             // Theme-extension hooks. Theme subclasses override these by
             // returning their own markup before delegating to parent.
             'hero',
@@ -226,6 +226,37 @@ class Site
             $msg['header'] = $header;
         }
         $this->msgs[] = $msg;
+    }
+
+    /**
+     * Render the pending `$msgs[]` queue as a `<ul class="messages">`
+     * list and drain it. Empty queue returns an empty string so a
+     * template can call `<?= $site->render('messages') ?>` without
+     * conditionals. Markup mirrors {@see Editor::renderMsgs()} so the
+     * frontend and editor share the same CSS hooks. The `value` is
+     * emitted raw — addMsg() callers are trusted to either pass
+     * static strings or escape themselves; the `type` and `header`
+     * are HTML-escaped because they are intended to be plain text.
+     */
+    public function renderMsgs(): string
+    {
+        if ($this->msgs === []) {
+            return '';
+        }
+        $html = '<ul class="messages">';
+        foreach ($this->msgs as $msg) {
+            $html .= sprintf(
+                '<li class="msg msg-%s">%s%s</li>',
+                htmlspecialchars((string) $msg['type'], \ENT_QUOTES),
+                isset($msg['header']) && $msg['header'] !== ''
+                    ? '<strong>' . htmlspecialchars((string) $msg['header'], \ENT_QUOTES) . '</strong> '
+                    : '',
+                (string) $msg['value'],
+            );
+        }
+        $html .= '</ul>';
+        $this->msgs = [];
+        return $html;
     }
 
     /**

--- a/themes/basic/resources/chunks/_sidebar-right.php
+++ b/themes/basic/resources/chunks/_sidebar-right.php
@@ -19,7 +19,7 @@
 				<div id="page-header">
 					<h1><?php echo $site->page->name; ?></h1>
 				</div>
-				<?php echo $site->messages; ?>
+				<?php echo $site->render('messages'); ?>
 				<div id="content" role="article">
 					<?php echo $site->render('content'); ?>
 				</div>


### PR DESCRIPTION
Site had two parallel properties that never agreed:

  public string $messages = '';   // never assigned
  public array  $msgs    = [];    // filled by addMsg()

and the render('messages') hook returned the empty string property, so a theme that called addMsg('success', '...') after a POST got nothing on screen. Same shape mismatch in the bundled basic theme: _sidebar-right.php read $site->messages directly, also always empty.

Fix mirrors the editor's helper for the same CSS hooks:

- New Site::renderMsgs() builds <ul class="messages"><li class="msg msg-{type}">...</li></ul>, drains $msgs[] on render, returns '' for an empty queue so templates can call <?= $site->render('messages') ?> without conditionals.
- render('messages') dispatches to renderMsgs() instead of the empty string property.
- Dead `public string $messages` property removed.
- themes/basic/resources/chunks/_sidebar-right.php migrates from <?= $site->messages ?> to <?= $site->render('messages') ?>.

External themes that read $site->messages directly need to migrate to $site->render('messages') (which was the documented path all along, just non-functional).