### PR TITLE
feat(basic-theme): style the messages slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,15 @@
 
 ### Added
 
+- **Basic theme: styles for the `messages` slot.** The bundled
+  `basic` theme's `styles.css` had no rules for the
+  `<ul class="messages"><li class="msg msg-{type}">…</li></ul>`
+  markup that `Site::renderMsgs()` emits, so flash messages
+  rendered as an unstyled bullet list. Adds a six-token status
+  palette (`--color-success-*`, `--color-danger-*`) on
+  `:root` plus matching `ul.messages` / `.messages .msg` /
+  `.msg-success` / `.msg-error` rules. Themes that want a
+  different look override the three tokens per state.
 - **`$site->flashMsg($type, $text, $header = '')`** for POST-redirect-GET
   on the frontend. Mirrors `Editor::flashMsg()`: writes the message
   into the session bag, the next request's `renderMsgs()` folds it

--- a/public/themes/basic/css/styles.css
+++ b/public/themes/basic/css/styles.css
@@ -54,6 +54,16 @@
 	/* --border-black-color: #020202; */
 	--dark-color: #172138;
 	--dark-active-color: #293658;
+	/* Status palette for `$site->render('messages')`. Pastel tones
+	   pick up the editor's `<ul class="messages"><li class="msg
+	   msg-{type}">` shape; themes that want stronger colors can
+	   override the three tokens per state. */
+	--color-success-bg: #e8f5ec;
+	--color-success: #1f6b3a;
+	--color-success-border: #b7dcc0;
+	--color-danger-bg: #fbeaea;
+	--color-danger: #8c2222;
+	--color-danger-border: #e6b7b7;
 }
 
 html {
@@ -238,6 +248,34 @@ form button {
 
 form button:hover {
 	background-color: var(--dark-active-color);
+}
+
+/* Message slot rendered by `$site->render('messages')` —
+   matches the markup `<ul class="messages"><li class="msg
+   msg-{type}">…</li></ul>` that Site::renderMsgs() emits. */
+ul.messages {
+	list-style: none;
+	margin: 1em 0;
+	padding: 0;
+}
+.messages .msg {
+	padding: 12px 16px;
+	border-radius: 6px;
+	border: solid 1px transparent;
+	margin-bottom: 8px;
+}
+.messages .msg:last-child {
+	margin-bottom: 0;
+}
+.msg-success {
+	background-color: var(--color-success-bg);
+	color: var(--color-success);
+	border-color: var(--color-success-border);
+}
+.msg-error {
+	background-color: var(--color-danger-bg);
+	color: var(--color-danger);
+	border-color: var(--color-danger-border);
 }
 
 footer .uk-nav li>a>span {


### PR DESCRIPTION
Site::renderMsgs() emits
<ul class="messages"><li class="msg msg-{type}">…</li></ul> but the bundled basic theme's styles.css had zero rules for it, so flash messages rendered as an unstyled bullet list. Add a six-token status palette on :root plus the matching messages rules so a fresh Scriptor install looks decent after a flashMsg() / addMsg() out of the box.

- :root grows `--color-success-{bg,fg,border}` and `--color-danger-{bg,fg,border}` with soft pastel defaults. Themes that want stronger colors override the three tokens per state without redefining the whole rule set.
- `ul.messages` resets the list chrome; `.messages .msg` adds padding + radius + bottom margin; `.msg-success` / `.msg-error` paint the role colors.

Shape mirrors the editor's existing message styles in public/editor-assets/css/styles.css so the two surfaces stay visually coherent even though they live in separate stylesheets.