### PR TITLE
feat(logging): PSR-3 FileLogger + container binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,20 @@
 
 ### Added
 
+- **PSR-3 logger surface.** Until now Scriptor had no first-class
+  logger; tutorial and bundled handlers fell back to `error_log()`,
+  which is hard to scope and hard to find. Adds
+  `Psr\Log\LoggerInterface` as a container-bound service and a
+  small `Scriptor\Boot\Logging\FileLogger` default (~80 lines, no
+  new Composer deps — `psr/log:^3` is already transitive). Writes
+  one line per record to `data/logs/scriptor.log` (path +
+  min-level configurable via `$config['logging']`), with PSR-3
+  `{placeholder}` interpolation and `LOCK_EX` for concurrent FPM
+  workers. `Site::$logger` and `Editor::$logger` expose the
+  instance; themes and plugins can pull `LoggerInterface` directly
+  from the container. Swap the binding in `boot.php` to wire in
+  Monolog or any other PSR-3 implementation without touching call
+  sites.
 - **Basic theme: styles for the `messages` slot.** The bundled
   `basic` theme's `styles.css` had no rules for the
   `<ul class="messages"><li class="msg msg-{type}">…</li></ul>`

--- a/boot.php
+++ b/boot.php
@@ -2,11 +2,13 @@
 
 declare(strict_types=1);
 
+use Psr\Log\LoggerInterface;
 use Scriptor\Boot\App;
 use Scriptor\Boot\Editor\Menu\MenuRegistry;
 use Scriptor\Boot\Editor\ModuleRegistry;
 use Scriptor\Boot\Frontend\Nav\FrontendNavRegistry;
 use Scriptor\Boot\ImanagerBootstrap;
+use Scriptor\Boot\Logging\FileLogger;
 use Scriptor\Boot\Plugin\PluginManager;
 
 require __DIR__ . '/vendor/autoload.php';
@@ -70,6 +72,26 @@ if (file_exists(__DIR__ . '/data/settings/custom.scriptor-config.php')) {
 // per-request services like Editor or Site exist.
 App::container()->add('scriptor.config', $config);
 App::container()->add('scriptor.root',   __DIR__);
+
+// Default PSR-3 logger. Themes, plugins, and Scriptor's own
+// modules pull `LoggerInterface` from the container; the binding
+// here picks Scriptor's tiny file logger and reads its config from
+// `$config['logging']`. Swap this binding to wire in Monolog or
+// any other PSR-3 implementation without touching call sites.
+//
+// We use `extend()` rather than `addShared()` because iManager's
+// Bootstrap pre-registers a NullLogger; `addShared()` would just
+// append a second definition that league/container would skip in
+// favour of the older one. `extend()` swaps the concrete on the
+// existing definition so consumers still resolve a single instance.
+App::container()
+    ->extend(LoggerInterface::class)
+    ->setConcrete(static function () use ($config): LoggerInterface {
+        $logging = (array) ($config['logging'] ?? []);
+        $path  = (string) ($logging['path']  ?? __DIR__ . '/data/logs/scriptor.log');
+        $level = (string) ($logging['level'] ?? 'info');
+        return new FileLogger($path, $level);
+    });
 
 $pluginManager = new PluginManager(
     container:   App::container(),

--- a/boot/Editor/Editor.php
+++ b/boot/Editor/Editor.php
@@ -11,6 +11,7 @@ use Imanager\Http\UrlSegments;
 use Imanager\Templating\TemplateRenderer;
 use Imanager\Validation\Sanitizer as ImanagerSanitizer;
 use League\Container\Container;
+use Psr\Log\LoggerInterface;
 use Scriptor\Boot\Frontend\Sanitizer;
 
 /**
@@ -20,7 +21,7 @@ use Scriptor\Boot\Frontend\Sanitizer;
  *
  *   - Properties:  config, siteUrl, themeUrl, version, csrf, msgs[],
  *                  pageTitle, pageContent, breadcrumbs, jsConfig,
- *                  i18n, input, sanitizer, urlSegments, session
+ *                  i18n, input, sanitizer, urlSegments, session, logger
  *   - Helpers:     getProperty(), getResources(), addMsg(), renderMsgs(),
  *                  isLoggedIn(), currentUserId(), templateName()
  *
@@ -50,6 +51,7 @@ class Editor
     public UrlSegments $urlSegments;
     public TemplateRenderer $templateParser;
     public SessionStore $session;
+    public LoggerInterface $logger;
 
     /** @var array<string, mixed> */
     public array $config;
@@ -72,6 +74,7 @@ class Editor
         $this->config = $config;
         $this->csrf = $container->get(Csrf::class);
         $this->session = $container->get(SessionStore::class);
+        $this->logger = $container->get(LoggerInterface::class);
         $this->input = Request::fromGlobals();
         $this->sanitizer = new Sanitizer($container->get(ImanagerSanitizer::class));
         $this->templateParser = new TemplateRenderer();

--- a/boot/Frontend/Site.php
+++ b/boot/Frontend/Site.php
@@ -15,6 +15,7 @@ use Imanager\Templating\TemplateRenderer;
 use Imanager\Validation\Sanitizer as ImanagerSanitizer;
 use League\Container\Container;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
 use Scriptor\Boot\Events\Frontend\ContentRendering;
 use Scriptor\Boot\Events\Frontend\PageResolved;
 use Scriptor\Boot\Events\Frontend\PageResolving;
@@ -26,8 +27,8 @@ use Scriptor\Boot\Events\Frontend\RouteNotFound;
  *
  * Holds the `$site` surface that bundled themes consume:
  *   - properties: `siteUrl`, `themeUrl`, `version`, `config`, `page`,
- *     `urlSegments`, `input`, `sanitizer`, `pages`,
- *     `templateParser`, `cache`
+ *     `urlSegments`, `input`, `sanitizer`, `session`, `logger`,
+ *     `pages`, `templateParser`, `cache`
  *   - rendering: `render($element)` with overridable hooks; theme
  *     subclasses override the `render*()` methods. The `messages`
  *     element renders the pending `$msgs[]` queue as HTML.
@@ -47,6 +48,7 @@ class Site
     public Request $input;
     public Sanitizer $sanitizer;
     public SessionStore $session;
+    public LoggerInterface $logger;
     public PageRepository $pages;
     public TemplateRenderer $templateParser;
     public FilesystemCache $cache;
@@ -112,6 +114,7 @@ class Site
         $this->config = $config;
         $this->sanitizer = new Sanitizer($container->get(ImanagerSanitizer::class));
         $this->session = $container->get(SessionStore::class);
+        $this->logger  = $container->get(LoggerInterface::class);
         // If a session cookie is already in the request, open the
         // session now so {@see renderMsgs()} can drain the flash bag
         // without trying to call session_start() mid-template (after

--- a/boot/Logging/FileLogger.php
+++ b/boot/Logging/FileLogger.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Logging;
+
+use Psr\Log\AbstractLogger;
+use Psr\Log\InvalidArgumentException;
+use Psr\Log\LogLevel;
+
+/**
+ * Append-only, single-file PSR-3 logger.
+ *
+ * The default Scriptor logger. Picks the path + min level from
+ * `$config['logging']` and writes one line per record to a flat
+ * text file under `data/logs/`. No rotation, no remote sinks; if
+ * you need either, swap the container binding for Monolog or your
+ * preferred PSR-3 implementation in `boot.php`.
+ *
+ * Line shape (Monolog-ish, intentional so the file is greppable
+ * with the usual tools):
+ *
+ *     [2026-05-22T14:23:00+02:00] INFO: Contact form submitted from juri@example.com
+ *
+ * `{placeholder}` tokens in the message are substituted from the
+ * `$context` array per PSR-3 §1.2. Throwable values stringify to
+ * their `getMessage()`; objects with `__toString()` stringify via
+ * that method; arrays / non-stringable objects are left as-is so
+ * the caller decides on their own format.
+ */
+final class FileLogger extends AbstractLogger
+{
+    /**
+     * Numeric rank for each PSR-3 level. Higher = more severe.
+     * Records whose level rank is below the configured min are
+     * dropped silently. Order matches the PSR-3 spec.
+     *
+     * @var array<string, int>
+     */
+    private const LEVEL_RANK = [
+        LogLevel::DEBUG     => 0,
+        LogLevel::INFO      => 1,
+        LogLevel::NOTICE    => 2,
+        LogLevel::WARNING   => 3,
+        LogLevel::ERROR     => 4,
+        LogLevel::CRITICAL  => 5,
+        LogLevel::ALERT     => 6,
+        LogLevel::EMERGENCY => 7,
+    ];
+
+    private readonly int $minRank;
+
+    public function __construct(
+        private readonly string $path,
+        string $minLevel = LogLevel::INFO,
+    ) {
+        if (! isset(self::LEVEL_RANK[$minLevel])) {
+            throw new InvalidArgumentException(
+                'Unknown PSR-3 level: "' . $minLevel . '". '
+                . 'Use one of: ' . implode(', ', array_keys(self::LEVEL_RANK)),
+            );
+        }
+        $this->minRank = self::LEVEL_RANK[$minLevel];
+    }
+
+    /**
+     * @param mixed              $level   PSR-3 LogLevel::* constant or matching string.
+     * @param string|\Stringable $message
+     * @param array<string, mixed> $context
+     */
+    public function log($level, $message, array $context = []): void
+    {
+        $levelKey = \is_string($level) ? $level : (string) $level;
+        if (! isset(self::LEVEL_RANK[$levelKey])) {
+            throw new InvalidArgumentException('Unknown PSR-3 level: "' . $levelKey . '"');
+        }
+        if (self::LEVEL_RANK[$levelKey] < $this->minRank) {
+            return;
+        }
+
+        $line = sprintf(
+            "[%s] %s: %s\n",
+            date('c'),
+            strtoupper($levelKey),
+            self::interpolate((string) $message, $context),
+        );
+
+        // Lazy mkdir so a deleted `data/logs/` doesn't kill logging.
+        $dir = \dirname($this->path);
+        if (! is_dir($dir)) {
+            @mkdir($dir, 0775, true);
+        }
+        // LOCK_EX serialises concurrent FPM workers writing the same
+        // file. The @ suppresses the warning when the file is on a
+        // read-only mount during a misconfigured deploy; the caller
+        // would notice via missing log lines.
+        @file_put_contents($this->path, $line, \FILE_APPEND | \LOCK_EX);
+    }
+
+    /**
+     * PSR-3 §1.2 message interpolation. Replaces `{key}` tokens in
+     * the message with the matching `$context[key]` value. Scalars
+     * and `Stringable` objects stringify; Throwables stringify to
+     * their getMessage(); other values are left untouched so the
+     * unreplaced `{key}` reaches the log unmodified (a clear sign
+     * the caller passed something we can't render).
+     *
+     * @param array<string, mixed> $context
+     */
+    private static function interpolate(string $message, array $context): string
+    {
+        if ($context === [] || strpos($message, '{') === false) {
+            return $message;
+        }
+        $replace = [];
+        foreach ($context as $key => $val) {
+            if (! \is_string($key)) {
+                continue;
+            }
+            // Check Throwable BEFORE Stringable: Throwable implements
+            // Stringable, but its __toString() returns the full stack
+            // trace, which would explode a single log line. Loggers
+            // generally want just the message; full trace stays
+            // accessible via the `exception` context key per PSR-3
+            // §1.3 if a downstream handler wants it.
+            if ($val instanceof \Throwable) {
+                $replace['{' . $key . '}'] = $val->getMessage();
+            } elseif ($val === null || \is_scalar($val) || $val instanceof \Stringable) {
+                $replace['{' . $key . '}'] = (string) $val;
+            }
+        }
+        return strtr($message, $replace);
+    }
+}

--- a/data/settings/scriptor-config.php
+++ b/data/settings/scriptor-config.php
@@ -116,10 +116,32 @@ $config = [
 
 	/**
 	 * Maximum number of configuration files to be saved as backup.
-	 * 
+	 *
 	 * @var integer
 	 */
 	'maxConfigBackupFiles' => 5,
+
+	/**
+	 * PSR-3 file logger settings, consumed by the default
+	 * `Scriptor\Boot\Logging\FileLogger` binding in `boot.php`.
+	 *
+	 *   path:  absolute path to the log file. Parent dir is
+	 *          created on first write.
+	 *   level: minimum PSR-3 level that gets written; records
+	 *          below are dropped. One of:
+	 *          debug | info | notice | warning | error |
+	 *          critical | alert | emergency
+	 *
+	 * Swap the LoggerInterface container binding in `boot.php` to
+	 * wire in Monolog or another PSR-3 implementation without
+	 * touching the call sites.
+	 *
+	 * @var array{path: string, level: string}
+	 */
+	'logging' => [
+		'path'  => __DIR__ . '/../logs/scriptor.log',
+		'level' => 'info',
+	],
 
 	/**
 	 * Array with reserved slugs.


### PR DESCRIPTION
Until now Scriptor had no first-class logger; tutorial chapter 6's contactAction fell back to error_log() and the rest of the boot code had no logging surface at all. Adds a small append-only PSR-3 logger plus the container plumbing to make it discoverable.

- boot/Logging/FileLogger.php (~110 lines, no new Composer deps; psr/log:^3 is already transitive). One line per record in Monolog-ish shape so the file is greppable. PSR-3 §1.2 {placeholder} interpolation; Throwables stringify to getMessage() rather than the full trace (Throwable implements Stringable but its __toString() includes the trace — a single log line would explode). Min-level filter; unknown level raises Psr\Log\InvalidArgumentException up front. Lazy mkdir on the parent dir so a deleted data/logs/ doesn't kill logging.
- boot.php uses container->extend(LoggerInterface::class) (not addShared) because iManager's Bootstrap pre-binds a NullLogger; addShared would just append a second definition that league/ container then skips. extend() swaps the concrete on the existing definition.
- $config['logging']['path' | 'level'] in scriptor-config.php defaults to data/logs/scriptor.log and 'info'. Documented inline with the same shape the rest of the config file uses.
- Site::$logger and Editor::$logger expose the resolved instance so theme actions can call `$site->logger->info(...)` without digging into the container.

Swap the binding in boot.php to wire in Monolog or any other PSR-3 implementation without touching call sites.