### PR TITLE
feat(http): Site::redirect() + Editor::redirect() + cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,16 @@
 
 ### Added
 
+- **`Site::redirect()` + `Editor::redirect()` helpers.** Themes
+  and editor modules can now call
+  `$site->redirect('/contact/', 303)` (or `$editor->redirect(...)`)
+  to send a Location header and stop the request. Default status
+  is 302; pass 303 for the POST-redirect-GET pattern alongside
+  `flashMsg()`, 301 for permanent rewrites, 307 to preserve the
+  request method. Cleanup deduplicates four
+  `private function redirect()` copies that lived in EditorRouter,
+  AuthModule, ProfileModule, and PagesModule — all now delegate
+  to the single `Editor::redirect()` implementation.
 - **PSR-3 logger surface.** Until now Scriptor had no first-class
   logger; tutorial and bundled handlers fell back to `error_log()`,
   which is hard to scope and hard to find. Adds

--- a/boot/Editor/Auth/AuthModule.php
+++ b/boot/Editor/Auth/AuthModule.php
@@ -33,7 +33,7 @@ final class AuthModule implements Module
         $this->checkAction();
 
         if ($this->editor->isLoggedIn()) {
-            $this->redirect($this->editor->siteUrl . '/');
+            $this->editor->redirect($this->editor->siteUrl . '/');
         }
         $this->editor->pageTitle = 'Login - Scriptor';
         $this->editor->pageContent = $this->renderLoginForm();
@@ -104,7 +104,7 @@ final class AuthModule implements Module
         $this->editor->csrf->clear();
         $this->attempts->reset();
         $this->editor->flashMsg('success', $this->t('successful_login'));
-        $this->redirect($this->editor->siteUrl . '/');
+        $this->editor->redirect($this->editor->siteUrl . '/');
     }
 
     private function logoutAction(): void
@@ -120,7 +120,7 @@ final class AuthModule implements Module
         $this->editor->session->remove('userid');
         $this->editor->csrf->clear();
         $this->editor->flashMsg('success', $this->t('successful_logout'));
-        $this->redirect($this->editor->siteUrl . '/auth/');
+        $this->editor->redirect($this->editor->siteUrl . '/auth/');
     }
 
     private function renderLoginForm(): string
@@ -167,12 +167,6 @@ final class AuthModule implements Module
             $template = str_replace('[[' . $name . ']]', $value, $template);
         }
         return $template;
-    }
-
-    private function redirect(string $url): never
-    {
-        header('Location: ' . $url, true, 302);
-        exit;
     }
 
     /**

--- a/boot/Editor/Editor.php
+++ b/boot/Editor/Editor.php
@@ -22,7 +22,8 @@ use Scriptor\Boot\Frontend\Sanitizer;
  *   - Properties:  config, siteUrl, themeUrl, version, csrf, msgs[],
  *                  pageTitle, pageContent, breadcrumbs, jsConfig,
  *                  i18n, input, sanitizer, urlSegments, session, logger
- *   - Helpers:     getProperty(), getResources(), addMsg(), renderMsgs(),
+ *   - Helpers:     getProperty(), getResources(), addMsg(),
+ *                  flashMsg(), renderMsgs(), redirect(),
  *                  isLoggedIn(), currentUserId(), templateName()
  *
  * Modules (AuthModule today, more in 14c-2…14c-6) populate `pageTitle`
@@ -157,6 +158,24 @@ class Editor
         $bag = (array) $this->session->get('msgs', []);
         $bag[] = ['type' => $type, 'value' => $text];
         $this->session->set('msgs', $bag);
+    }
+
+    /**
+     * Send a Location header and stop the request. Pairs with
+     * {@see flashMsg()} for the POST-redirect-GET pattern.
+     *
+     * Status-code cheat sheet:
+     *   - 303 (See Other)     after a POST handler; tells the browser
+     *                         to switch to GET so a reload does not
+     *                         resubmit the form
+     *   - 302 (Found)         default; generic temporary redirect
+     *   - 301 (Moved Permanently) permanent rewrites; cached
+     *   - 307 (Temporary)     preserves the request method
+     */
+    public function redirect(string $url, int $status = 302): never
+    {
+        header('Location: ' . $url, true, $status);
+        exit;
     }
 
     public function getProperty(string $name): mixed

--- a/boot/Editor/EditorRouter.php
+++ b/boot/Editor/EditorRouter.php
@@ -51,7 +51,7 @@ final class EditorRouter
             if ($first === 'api') {
                 $this->jsonError(401, 'Authentication required');
             }
-            $this->redirect($this->editor->siteUrl . '/auth/');
+            $this->editor->redirect($this->editor->siteUrl . '/auth/');
         }
 
         if ($first === 'api') {
@@ -131,9 +131,4 @@ final class EditorRouter
             . '<p>Module <code>' . htmlspecialchars($module, \ENT_QUOTES) . '</code> is not available.</p>';
     }
 
-    private function redirect(string $url): never
-    {
-        header('Location: ' . $url, true, 302);
-        exit;
-    }
 }

--- a/boot/Editor/Pages/PagesModule.php
+++ b/boot/Editor/Pages/PagesModule.php
@@ -211,7 +211,7 @@ final class PagesModule implements Module
         }
 
         $this->editor->flashMsg('success', $this->t('successful_saved_page') ?: 'Page saved.');
-        $this->redirect($redirect);
+        $this->editor->redirect($redirect);
     }
 
     /**
@@ -288,24 +288,24 @@ final class PagesModule implements Module
         $id = $this->editor->input->getInt('page', 0);
         if (! $this->csrfPasses($this->editor->input->getString('tokenName'), $this->editor->input->getString('tokenValue'))) {
             $this->editor->flashMsg('error', $this->t('error_csrf_token_mismatch'));
-            $this->redirect($this->editor->siteUrl . '/pages/');
+            $this->editor->redirect($this->editor->siteUrl . '/pages/');
         }
         if ($id <= 1) {
             $this->editor->flashMsg('error', $this->t('error_deleting_first_page') ?: 'The home page cannot be deleted.');
-            $this->redirect($this->editor->siteUrl . '/pages/');
+            $this->editor->redirect($this->editor->siteUrl . '/pages/');
         }
         $page = $this->pages->find($id);
         if ($page === null) {
             $this->editor->flashMsg('error', $this->t('error_deleting_page') ?: 'Page not found.');
-            $this->redirect($this->editor->siteUrl . '/pages/');
+            $this->editor->redirect($this->editor->siteUrl . '/pages/');
         }
         if ($this->pages->findByParent($id) !== []) {
             $this->editor->flashMsg('error', $this->t('error_remove_parent_page') ?: 'Cannot delete a page with child pages.');
-            $this->redirect($this->editor->siteUrl . '/pages/');
+            $this->editor->redirect($this->editor->siteUrl . '/pages/');
         }
         $this->pages->delete($id);
         $this->editor->flashMsg('success', $this->t('page_successful_removed') ?: 'Page deleted.');
-        $this->redirect($this->editor->siteUrl . '/pages/');
+        $this->editor->redirect($this->editor->siteUrl . '/pages/');
     }
 
     private function renumberAction(): void
@@ -730,9 +730,4 @@ final class PagesModule implements Module
         exit;
     }
 
-    private function redirect(string $url): never
-    {
-        header('Location: ' . $url, true, 302);
-        exit;
-    }
 }

--- a/boot/Editor/Profile/ProfileModule.php
+++ b/boot/Editor/Profile/ProfileModule.php
@@ -38,12 +38,12 @@ final class ProfileModule implements Module
         if ($currentId === null) {
             // Auth gate guarantees this on `/editor/profile`, but defend
             // against direct callers anyway.
-            $this->redirect($this->editor->siteUrl . '/auth/');
+            $this->editor->redirect($this->editor->siteUrl . '/auth/');
         }
 
         $sub = $this->editor->urlSegments->get(1);
         if ($sub === null) {
-            $this->redirect($this->editor->siteUrl . '/profile/edit/?profile=' . $currentId);
+            $this->editor->redirect($this->editor->siteUrl . '/profile/edit/?profile=' . $currentId);
         }
 
         if ($sub !== 'edit') {
@@ -140,7 +140,7 @@ final class ProfileModule implements Module
         }
 
         $this->editor->flashMsg('success', $this->t('profile_successful_saved'));
-        $this->redirect($this->editor->siteUrl . '/profile/edit/?profile=' . $currentId);
+        $this->editor->redirect($this->editor->siteUrl . '/profile/edit/?profile=' . $currentId);
     }
 
     private function renderEdit(int $currentId): void
@@ -239,9 +239,4 @@ final class ProfileModule implements Module
         return $this->editor->i18n[$key] ?? '';
     }
 
-    private function redirect(string $url): never
-    {
-        header('Location: ' . $url, true, 302);
-        exit;
-    }
 }

--- a/boot/Frontend/Site.php
+++ b/boot/Frontend/Site.php
@@ -33,7 +33,8 @@ use Scriptor\Boot\Events\Frontend\RouteNotFound;
  *     subclasses override the `render*()` methods. The `messages`
  *     element renders the pending `$msgs[]` queue as HTML.
  *   - utilities: `getBasePath()`, `getPageUrl()`, `addMsg()`,
- *     `throw404()`, `getTCP()`, `templateName()`.
+ *     `flashMsg()`, `redirect()`, `throw404()`, `getTCP()`,
+ *     `templateName()`.
  *
  * Themes extend this class and override `render()`, individual
  * `render*()` methods, or `init()` to set theme-specific config.
@@ -244,6 +245,28 @@ class Site
     public function getTCP(string $key): mixed
     {
         return $this->themeConfig[$key] ?? self::TCP_DEFAULTS[$key] ?? null;
+    }
+
+    /**
+     * Send a Location header and stop the request. Pairs with the
+     * {@see flashMsg()} session bag for the POST-redirect-GET pattern.
+     *
+     * Status-code cheat sheet:
+     *   - 303 (See Other)     after a POST handler; tells the browser
+     *                         to switch to GET so a reload of the
+     *                         landing page does not resubmit the form
+     *   - 302 (Found)         default; generic "go here for now",
+     *                         method preservation is implementation-
+     *                         defined
+     *   - 301 (Moved Permanently) for permanent rewrites; cached by
+     *                         clients and proxies
+     *   - 307 (Temporary)     preserves the request method (rare for
+     *                         a CMS, useful for an API surface)
+     */
+    public function redirect(string $url, int $status = 302): never
+    {
+        header('Location: ' . $url, true, $status);
+        exit;
     }
 
     /**


### PR DESCRIPTION
Four editor modules (EditorRouter, AuthModule, ProfileModule, PagesModule) each carried a private `function redirect(string $url): never { header('Location: ' . $url, true, 302); exit; }` — same implementation copy-pasted four times. Themes had no official redirect helper at all, so the build-a-theme tutorial fell back to `header() + exit` inline in chapter 6.

Add the helper once on both top-level surfaces:

  $site->redirect($url, int $status = 302): never
  $editor->redirect($url, int $status = 302): never

Default status is 302 (matches the duplicates we removed). The docblock spells out the choices that actually matter:

  303 (See Other)        after a POST handler — switch to GET so
                         reload does not resubmit the form (PRG)
  302 (Found)            generic temporary
  301 (Moved Permanently) cached permanent rewrite
  307 (Temporary)        preserves the request method

The four editor modules now delegate to $this->editor->redirect() and drop their private copies. Caller sites stay one line each:

  $this->editor->redirect($this->editor->siteUrl . '/pages/');

Pairs with `flashMsg()`: the next chapter-6 tutorial PR uses $site->redirect(..., 303) right after flashMsg() to fix the "reload duplicates the success message" naive-form bug.