### PR TITLE
feat(docker): support full-dump seeds via seed-demo-full.sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Added
 
+- **Docker entrypoint full-dump seed mode**. When the operator bind-mounts
+  a SQL dump at `/var/www/scriptor/docker/seed-demo-full.sql`, the
+  entrypoint skips `bin/scriptor install` + `seed-demo-content.sql`
+  overlay and applies the dump directly via `sqlite3`. The dump is then
+  authoritative for the whole DB (categories, fields, items, users).
+  File-presence is the switch — no env var, no extra config. Sites that
+  ship a captured `imanager dump` of their production content (e.g.
+  scriptor-cms-site's `seed-site.sql`) can use this path without forcing
+  the dump to be rewritten as an overlay on top of the install seed.
 - **`bin/scriptor install` CLI** for greenfield setup. Seeds the
   Pages + Users categories, their fields, an admin user, and a
   minimal Home page so `/` works on the first request. Replaces

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,7 +3,9 @@ set -eu
 
 # Entrypoint for the Scriptor demo container.
 #
-# On first start (no SQLite DB yet) we bootstrap a fresh demo:
+# On first start (no SQLite DB yet) we bootstrap one of two ways:
+#
+# Default flow (no full-dump mounted):
 #   1. bin/scriptor install            seeds Pages + Users + admin +
 #                                       minimal Home via the same CLI
 #                                       a bare-metal install uses
@@ -13,16 +15,30 @@ set -eu
 #   3. docker/seed-demo-uploads.tar.gz the uploaded images those pages
 #                                       reference, extracted into public/
 #
+# Full-dump flow (operator bind-mounts docker/seed-demo-full.sql):
+#   1. docker/seed-demo-full.sql       applied directly via sqlite3
+#                                       (creates categories/items/users
+#                                       from the dump, no `bin/scriptor
+#                                       install` involved)
+#   2. docker/seed-demo-uploads.tar.gz unchanged, still extracted
+#
+#   The presence of SEED_FULL is the switch — no env var. Operators
+#   pointing at a captured `imanager dump` of an existing site (e.g.
+#   scriptor-cms-site mounts seed-site.sql there) skip the install
+#   step entirely and let the dump rebuild the DB from scratch.
+#
 # On every start we then run schema:migrate, so an existing DB carried
 # over from an older image catches up to whatever migrations this image
 # carries.
 #
 # Admin credentials: SCRIPTOR_ADMIN_PASSWORD from docker-compose.yml is
 # passed straight to `bin/scriptor install`. The demo's default value
-# is gT5nLazzyBob and matches docs/demo.md.
+# is gT5nLazzyBob and matches docs/demo.md. Only consulted in the
+# default flow; full-dump flow carries its own user rows.
 
 APP_DIR=/var/www/scriptor
 DB_PATH="${APP_DIR}/data/imanager.db"
+SEED_FULL="${APP_DIR}/docker/seed-demo-full.sql"
 SEED_CONTENT="${APP_DIR}/docker/seed-demo-content.sql"
 SEED_UPLOADS="${APP_DIR}/docker/seed-demo-uploads.tar.gz"
 
@@ -42,21 +58,27 @@ if [ "$(id -u)" = "0" ]; then
 fi
 
 if [ ! -f "${DB_PATH}" ]; then
-    if [ -z "${SCRIPTOR_ADMIN_PASSWORD:-}" ]; then
-        echo "[entrypoint] FATAL: SCRIPTOR_ADMIN_PASSWORD env not set" >&2
-        echo "[entrypoint] docker-compose.yml ships a default; check that the value is propagating to the container" >&2
-        exit 1
-    fi
+    if [ -f "${SEED_FULL}" ]; then
+        echo "[entrypoint] full-dump seed present at ${SEED_FULL}, applying directly."
+        echo "[entrypoint] skipping bin/scriptor install — the dump rebuilds the DB."
+        su -s /bin/sh -c "sqlite3 ${DB_PATH} < ${SEED_FULL}" www-data
+    else
+        if [ -z "${SCRIPTOR_ADMIN_PASSWORD:-}" ]; then
+            echo "[entrypoint] FATAL: SCRIPTOR_ADMIN_PASSWORD env not set" >&2
+            echo "[entrypoint] docker-compose.yml ships a default; check that the value is propagating to the container" >&2
+            exit 1
+        fi
 
-    echo "[entrypoint] no database, running bin/scriptor install."
-    su -s /bin/sh www-data -c "\
-        SCRIPTOR_ADMIN_PASSWORD='${SCRIPTOR_ADMIN_PASSWORD}' \
-        php bin/scriptor install --yes \
-    "
+        echo "[entrypoint] no database, running bin/scriptor install."
+        su -s /bin/sh www-data -c "\
+            SCRIPTOR_ADMIN_PASSWORD='${SCRIPTOR_ADMIN_PASSWORD}' \
+            php bin/scriptor install --yes \
+        "
 
-    if [ -f "${SEED_CONTENT}" ]; then
-        echo "[entrypoint] overlaying ${SEED_CONTENT}."
-        su -s /bin/sh -c "sqlite3 ${DB_PATH} < ${SEED_CONTENT}" www-data
+        if [ -f "${SEED_CONTENT}" ]; then
+            echo "[entrypoint] overlaying ${SEED_CONTENT}."
+            su -s /bin/sh -c "sqlite3 ${DB_PATH} < ${SEED_CONTENT}" www-data
+        fi
     fi
 
     if [ -f "${SEED_UPLOADS}" ]; then


### PR DESCRIPTION
The Docker entrypoint had one bootstrap path: `bin/scriptor install` followed by an `seed-demo-content.sql` overlay. That works for the canonical demo, but breaks when an operator wants to ship a captured `imanager dump` of an existing site — the dump's `CREATE TABLE` statements collide with the categories the install CLI just created.

scriptor-cms-site hit exactly this: its `seed-site.sql` is a full dump, was historically bind-mounted at `docker/seed-demo.sql` (the pre-29ce6b0 layout), and silently stopped applying when the upstream renamed the file. The cms-site bind-mount went nowhere and the container booted the default Scriptor demo content instead.

Fix at the right layer: the entrypoint detects an optional `docker/seed-demo-full.sql` bind-mount. When present, it skips `bin/scriptor install` + the content overlay and applies the dump directly. Uploads tarball extraction is unchanged. File presence is the switch — no env var, no extra config. The default path is unchanged when no full-dump is mounted.

Smoke:

  # Full-mode (seed-site.sql mounted)
  docker run --rm \
    -e SCRIPTOR_ADMIN_PASSWORD=smokepass \
    -v .../seed-site.sql:/var/www/scriptor/docker/seed-demo-full.sql:ro \
    --entrypoint /usr/local/bin/entrypoint.sh \
    bigins/scriptor-demo:smoke-fullmode \
    /bin/sh -c 'sqlite3 .../imanager.db "SELECT id,name FROM items..."'
  → Home id=1, Contact id=6, Legal id=7, Data protection id=8,
    gallery id=43, admin id=42 (matches seed-site.sql header).

  # Default mode (no SEED_FULL)
  Same command without the bind-mount
  → Home id=2 (install), Articles id=3..9 (content overlay),
    admin id=1 (install) — unchanged from before.