### PR TITLE
fix(docker): drop `immutable` from /uploads/ cache header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,20 @@
   for `bigins/*` plugins discoverable so the require works
   without further configuration.
 
+### Fixed
+
+- **Re-uploaded images no longer stick in the browser cache.**
+  `docker/nginx.conf` shipped `/uploads/` with `Cache-Control:
+  public, immutable` (plus 30-day `expires`). Upload URLs are
+  *not* content-addressed; re-uploading a file under the same
+  name leaves the URL stable while the bytes change, and
+  `immutable` told browsers to skip revalidation on reload. The
+  directive is now `must-revalidate`, so nginx's existing
+  `ETag` + `Last-Modified` headers do their job: 304 on hit when
+  the file on disk is unchanged (cheap), 200 with the new
+  content when it changed. Misleading "content-addressed" code
+  comment fixed alongside.
+
 ### Removed
 
 - `docker/seed-demo.sql`. The schema half is recreated by

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -65,11 +65,18 @@ http {
             return 404;
         }
 
-        # User uploads — long-cache; their URLs are content-addressed
-        # (path includes itemId/fieldId/<safe-filename>).
+        # User uploads. Long-cache, but revalidated. The URL is
+        # *not* content-addressed (path includes itemId/fieldId plus
+        # the user's original filename), so re-uploading a file under
+        # the same name leaves the URL stable while the bytes change.
+        # `must-revalidate` makes the browser send an If-None-Match
+        # for every hit; nginx's built-in ETag answers 304 when the
+        # file on disk is unchanged (cheap, no transfer) or 200 with
+        # the new content when it changed. `immutable` would skip the
+        # revalidation and serve a stale image for up to 30 days.
         location /uploads/ {
             expires 30d;
-            add_header Cache-Control          "public, immutable" always;
+            add_header Cache-Control          "public, must-revalidate" always;
             # Re-declare security headers because the parent's
             # add_header set is shadowed when this block has its own.
             add_header Content-Security-Policy $scriptor_security_csp always;


### PR DESCRIPTION
Upload URLs are not content-addressed. The path includes the owning category/field/item plus the user's original filename, which means re-uploading a file under the same name leaves the URL stable while the bytes change. `Cache-Control: public, immutable` told browsers to skip revalidation on reload, so a re-upload was invisible to anyone who had already loaded the original until the 30-day `expires` window ran out or the user manually cleared the cache.

Switch to `Cache-Control: public, must-revalidate`. nginx's built-in ETag + Last-Modified handling is unchanged; the browser now sends If-None-Match on every hit and gets:

- 304 Not Modified when the file on disk is unchanged (cheap, no body transfer)
- 200 with the new content when the file changed

Performance impact is one small conditional request per image per page load instead of zero. For sites with many images per page that becomes measurable; mitigation if it bites is to content-address the upload path (filename hash) and put `immutable` back. Not done here because it would break legacy URLs and is out of scope for the bug.

Fixes the "re-uploaded image still shows the old version" report against scriptor-cms.dev and surfaces in the user guide's files-and-images troubleshooting (scriptor-cms-ops docs/user-guide-files-multi-upload).

The misleading "URLs are content-addressed" comment that seeded the wrong cache decision is rewritten to reflect what the path actually contains and why must-revalidate is the right choice.