### PR TITLE
fix(docker): emit single Cache-Control header for /uploads/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,18 @@
   the file on disk is unchanged (cheap), 200 with the new
   content when it changed. Misleading "content-addressed" code
   comment fixed alongside.
+- **`/uploads/` no longer emits a duplicate `Cache-Control`
+  header.** Follow-up to the above: the previous version used
+  nginx's `expires 30d;` directive next to the explicit
+  `add_header Cache-Control "public, must-revalidate"`. The two
+  don't merge; nginx ended up emitting two separate
+  `Cache-Control` lines on every `/uploads/` response
+  (`max-age=2592000` from `expires`, then `public, must-revalidate`
+  from the `add_header`). Functionally correct per RFC 7234
+  (browsers combine combinable directives across header lines)
+  but ugly to debug. The `max-age=2592000` is now folded into the
+  single `add_header` line, `expires` is dropped, and the surrounding
+  comment explains why.
 
 ### Removed
 

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -74,9 +74,13 @@ http {
         # file on disk is unchanged (cheap, no transfer) or 200 with
         # the new content when it changed. `immutable` would skip the
         # revalidation and serve a stale image for up to 30 days.
+        #
+        # `max-age=2592000` (30d) is folded into the same header
+        # instead of using nginx's `expires 30d;` directive: the two
+        # don't merge, so `expires` would emit a *second* Cache-Control
+        # header next to ours, which is valid HTTP but ugly to debug.
         location /uploads/ {
-            expires 30d;
-            add_header Cache-Control          "public, must-revalidate" always;
+            add_header Cache-Control          "public, max-age=2592000, must-revalidate" always;
             # Re-declare security headers because the parent's
             # add_header set is shadowed when this block has its own.
             add_header Content-Security-Policy $scriptor_security_csp always;


### PR DESCRIPTION
The previous /uploads/ block used nginx's `expires 30d;` directive alongside an explicit `add_header Cache-Control "public, must-revalidate"`. The two don't merge: nginx emits one Cache-Control header from `expires` (`max-age=2592000`) and a second one from the `add_header` call.

Verified on live demo before the fix:

    $ curl -sSI https://scriptor-cms.dev/uploads/43/7/plugin-boot.png
    ...
    Cache-Control: max-age=2592000
    Cache-Control: public, must-revalidate

Per RFC 7234 §5.2 browsers combine combinable directives across multiple header lines, so the effective behavior was correct (`public, max-age=2592000, must-revalidate`), but two parallel Cache-Control headers are ugly to debug and trip up cache inspection tools that only read the first occurrence.

Fold `max-age=2592000` into the same `add_header` line and drop `expires 30d;`. Single header out, same caching semantics in. The surrounding comment now explains why the two directives are not mixed.

Verified `nginx -t` against the rewritten file inside the running cms-site container: syntax OK.

CHANGELOG: follow-up bullet under the existing 2.0.1+ Fixed entry for the immutable→must-revalidate change.