### PR TITLE
feat(editor): PSR-14 events for page-form field injection

### DIFF
--- a/boot/Editor/Pages/PagesModule.php
+++ b/boot/Editor/Pages/PagesModule.php
@@ -8,8 +8,11 @@ use Imanager\Domain\File;
 use Imanager\Domain\Item;
 use Imanager\Storage\FieldRepository;
 use Imanager\Storage\FileRepository;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Scriptor\Boot\Editor\Editor;
 use Scriptor\Boot\Editor\Module;
+use Scriptor\Boot\Events\Editor\PageFormRendering;
+use Scriptor\Boot\Events\Editor\PageSaving;
 use Scriptor\Boot\Frontend\Page;
 use Scriptor\Boot\Frontend\PageRepository;
 
@@ -38,6 +41,7 @@ final class PagesModule implements Module
         private readonly PageRepository $pages,
         private readonly FieldRepository $fields,
         private readonly FileRepository $files,
+        private readonly EventDispatcherInterface $dispatcher,
     ) {
         $reserved = (array) ($this->editor->config['reservedSlugs'] ?? []);
         /** @var list<int> $reserved */
@@ -200,6 +204,25 @@ final class PagesModule implements Module
             created:    $existing?->item->created ?? $now,
             updated:    $now,
         );
+
+        // Plugin extension point: let listeners pull extra POST fields
+        // into the item's data bag before persistence. Same plugin that
+        // rendered fields via PageFormRendering picks them up here.
+        $saving = new PageSaving($item, $this->editor->input);
+        $this->dispatcher->dispatch($saving);
+        if ($saving->extraData() !== []) {
+            $item = new Item(
+                id:         $item->id,
+                categoryId: $item->categoryId,
+                name:       $item->name,
+                label:      $item->label,
+                position:   $item->position,
+                active:     $item->active,
+                data:       [...$data, ...$saving->extraData()],
+                created:    $item->created,
+                updated:    $item->updated,
+            );
+        }
 
         try {
             $saved = $this->pages->save($item);
@@ -459,6 +482,16 @@ final class PagesModule implements Module
         $html .= $this->fieldText('template', 'template', $this->t('template_label'), $page?->template ?? '', infoText: $this->t('template_field_infotext'));
         $html .= $this->fieldPosition($page);
         $html .= $this->fieldCheckbox('publish', 'published', $this->t('published_label'), $page?->active() ?? true);
+
+        // Plugin extension point: render extra form-controls (SEO meta,
+        // scheduling, OG tags, …) between the core fields and the
+        // save controls. Buffer is appended verbatim; listeners own
+        // their HTML escaping. Companion {@see PageSaving} event lets
+        // the same plugin persist the posted values.
+        $rendering = new PageFormRendering($page, $this->pages->categoryId);
+        $this->dispatcher->dispatch($rendering);
+        $html .= $rendering->html();
+
         $html .= '<input type="hidden" name="action" value="save-page">';
         $html .= sprintf('<input type="hidden" name="tokenName" value="%s">', htmlspecialchars('pages', \ENT_QUOTES));
         $html .= sprintf('<input type="hidden" name="tokenValue" value="%s">', htmlspecialchars($token, \ENT_QUOTES));

--- a/boot/Events/Editor/PageFormRendering.php
+++ b/boot/Events/Editor/PageFormRendering.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Events\Editor;
+
+use Scriptor\Boot\Frontend\Page;
+
+/**
+ * Dispatched by {@see Scriptor\Boot\Editor\Pages\PagesModule} after the
+ * built-in form fields are rendered and before the form's hidden
+ * inputs + Save button so plugins can add their own fields (SEO meta,
+ * scheduling, OG tags, custom taxonomies, …) without forking
+ * PagesModule.
+ *
+ * Listeners append their `<div class="form-control">…</div>` markup
+ * via {@see appendHtml()}. The accumulated buffer is consumed by
+ * PagesModule and emitted verbatim into the form. The listener is
+ * responsible for its own escaping; the buffer is not re-encoded.
+ *
+ * Companion event {@see PageSaving} fires when the form is submitted
+ * so the same plugin can persist its values.
+ *
+ * Conventional listener body:
+ *
+ *     function (PageFormRendering $event): void {
+ *         $current = $event->page?->meta_title ?? '';
+ *         $event->appendHtml(
+ *             '<div class="form-control"><label for="meta-title">Meta title</label>'
+ *             . '<input id="meta-title" name="meta_title" type="text" value="'
+ *             . htmlspecialchars($current, ENT_QUOTES) . '"></div>'
+ *         );
+ *     }
+ */
+final class PageFormRendering
+{
+    private string $extraHtml = '';
+
+    public function __construct(
+        /** Page being edited; null for the new-page flow. */
+        public readonly ?Page $page,
+        /** id of the iManager category the form is editing. */
+        public readonly int $categoryId,
+    ) {}
+
+    /** Append markup to the buffer flushed into the form. */
+    public function appendHtml(string $html): void
+    {
+        $this->extraHtml .= $html;
+    }
+
+    /** All collected extra markup. PagesModule prints this verbatim. */
+    public function html(): string
+    {
+        return $this->extraHtml;
+    }
+}

--- a/boot/Events/Editor/PageSaving.php
+++ b/boot/Events/Editor/PageSaving.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Scriptor\Boot\Events\Editor;
+
+use Imanager\Domain\Item;
+use Imanager\Http\Request;
+
+/**
+ * Dispatched by {@see Scriptor\Boot\Editor\Pages\PagesModule::saveAction()}
+ * just before the page item is written to storage. Listeners read
+ * extra fields from the POST request and add them to {@see extraData},
+ * which PagesModule merges into the Item's data bag before the save.
+ *
+ * This is the persistence companion of {@see PageFormRendering}.
+ *
+ * `extraData` keys override matching core keys when merged (last-write-
+ * wins on the same key), so a listener can also override a built-in
+ * value if it wants to; the typical case is adding new keys (meta_*,
+ * og_*) the core doesn't know about.
+ *
+ * Conventional listener body:
+ *
+ *     function (PageSaving $event): void {
+ *         $event->mergeData([
+ *             'meta_title'       => trim($event->input->postString('meta_title')),
+ *             'meta_description' => trim($event->input->postString('meta_description')),
+ *         ]);
+ *     }
+ */
+final class PageSaving
+{
+    /** @var array<string, mixed> */
+    private array $extraData = [];
+
+    public function __construct(
+        /**
+         * The about-to-be-saved item with the core fields already
+         * populated from the form. Read-only; mutate via
+         * {@see mergeData()} so the merge order is predictable.
+         */
+        public readonly Item $item,
+
+        /** Per-request input bag. Listeners pull their own POST fields. */
+        public readonly Request $input,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $extra
+     */
+    public function mergeData(array $extra): void
+    {
+        $this->extraData = [...$this->extraData, ...$extra];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function extraData(): array
+    {
+        return $this->extraData;
+    }
+}

--- a/boot/Plugin/CorePlugins/CoreEditorPlugin.php
+++ b/boot/Plugin/CorePlugins/CoreEditorPlugin.php
@@ -62,6 +62,7 @@ final class CoreEditorPlugin implements Plugin
                 $c->get(PageRepository::class),
                 $c->get(FieldRepository::class),
                 $c->get(FileRepository::class),
+                $c->get(\Psr\EventDispatcher\EventDispatcherInterface::class),
             ));
 
         $context->registerEditorModule('profile', static fn (Container $c, Editor $e): Module


### PR DESCRIPTION
Adds two events plugins can subscribe to so they can extend the PagesModule edit form without forking PagesModule:

  - PageFormRendering: dispatched after the core fields and before the hidden action/csrf inputs. Listeners appendHtml() their own <div class="form-control">…</div> markup; the buffer is consumed by PagesModule and printed verbatim into the form.
  - PageSaving: dispatched after the about-to-be-saved Item is constructed and before the actual save. Listeners mergeData() extra keys (from event->input->postString(...)); PagesModule merges them into the item's data bag and saves once with the combined payload.

PagesModule pulls the dispatcher via constructor injection; the CoreEditorPlugin factory passes EventDispatcherInterface from the container. Both events live under Scriptor\Boot\Events\Editor/.

When no plugin subscribes, behaviour is identical to the previous version (empty buffer, empty extraData -> Item reused as-is).

These are the missing editor-side hooks called out as a gap in the Plugin API plan; flagged for a Scriptor master upstream PR (cherry-pick of the three boot/ files plus a cookbook recipe).