### PR TITLE
fix(editor+frontend): image thumbnails + preserve all data on page save

### DIFF
--- a/boot/Editor/Pages/PagesModule.php
+++ b/boot/Editor/Pages/PagesModule.php
@@ -737,13 +737,17 @@ final class PagesModule implements Module
      */
     private function existingDataMap(Page $page): array
     {
-        $out = [];
-        foreach (['slug', 'parent', 'pagetype', 'menu_title', 'content', 'template'] as $key) {
-            if ($page->item->data->has($key)) {
-                $out[$key] = $page->item->data->get($key);
-            }
-        }
-        return $out;
+        // Carry ALL existing keys forward, not just the six the
+        // form knows about. Hidden core fields (via
+        // PageFormRendering::hide) carry no POST value but should
+        // keep their stored data; legacy `images` JSON from 1.x
+        // imports lives here too; plugin-contributed keys whose
+        // PageSaving listener didn't fire (listener deactivated,
+        // event handler short-circuited on template) shouldn't get
+        // nuked on every save. The five POST-driven core keys are
+        // overwritten right after this call in saveAction(), so
+        // preserving them here is harmless.
+        return $page->item->data->toArray();
     }
 
     private function csrfPasses(string $name, string $value): bool

--- a/boot/Frontend/ImageUrlBuilder.php
+++ b/boot/Frontend/ImageUrlBuilder.php
@@ -57,7 +57,11 @@ final readonly class ImageUrlBuilder
         }
 
         $thumbName = self::thumbnailFilename($name, $width, $height);
-        $absDir    = $this->scriptorRoot . '/' . trim($publicDir, '/');
+        // `$publicDir` (e.g. "uploads/1.2.6/") is a URL-side path; on
+        // disk it lives under the public webroot. Prepend `public/`
+        // here so the source-exists check + the thumbnail write target
+        // both land where nginx / php-fpm actually serve from.
+        $absDir    = $this->scriptorRoot . '/public/' . trim($publicDir, '/');
         $absThumb  = $absDir . '/thumbnail/' . $thumbName;
         $absSource = $absDir . '/' . $name;
 


### PR DESCRIPTION
Two related bugs surfaced while migrating studenten-frankfurt.de's karaoke catalog from a single HTML blob to product-children pages.

ImageUrlBuilder::url($image, width: N)
  Computed the absolute on-disk path as
  `<scriptorRoot>/uploads/<dir>/<file>` but the actual files live
  under `<scriptorRoot>/public/uploads/...` since the Phase 14
  public-webroot refactor. is_file($absSource) returned false,
  generateThumbnail() was a no-op, and the returned URL
  (`/uploads/.../thumbnail/400x0_*.png`) 404'd. Fix: prepend
  `/public/` when assembling the absolute disk path. URLs the
  function hands back are unchanged.

PagesModule::existingDataMap()
  Listed six keys explicitly (slug, parent, pagetype, menu_title,
  content, template); everything else stored on the item's data
  bag was dropped on every page save. Effects:

    - Legacy `images` JSON from 1.x imports got wiped on the next editor save (PagesModule's image section reads only from the FileRepository, never repopulates data.images).
    - Plugin-contributed keys whose PageSaving listener was template-gated (e.g. the katalog plugin's price/deposit only re-merge for template=produkt) survived for some templates and not others, with no signal to the operator.
    - Hidden core fields (PageFormRendering::hide) lost their stored data the moment the page was saved with the field hidden.

  Fix: return $page->item->data->toArray(). The five POST-driven
  keys still get overwritten right after this call.

Both fixes are isolated and non-breaking: the URL string from ImageUrlBuilder is unchanged, and existingDataMap()'s output is now a strict superset of before.