### PR TITLE
chore(composer): drop bigins/* plugin VCS repositories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,6 @@
         "ext-pdo_sqlite": "*",
         "bigins/imanager": "^2.0"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/bigin/scriptor-markdown-pages"
-        }
-    ],
     "autoload": {
         "psr-4": {
             "Scriptor\\Boot\\": "boot/"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c7d1d06235f6a14b9e80e0fcc35b1af8",
+    "content-hash": "a6ded29a37e1197e411047273dbd5fcf",
     "packages": [
         {
             "name": "bigins/imanager",
@@ -1393,5 +1393,5 @@
     "platform-overrides": {
         "php": "8.2.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Scriptor ships as a clean, generic CMS; it should not carry the VCS source URLs of specific bigins/* plugins in its manifest. Those are consumer concerns and belong to whatever site installs the plugins (e.g. scriptor-cms-site supplies them at Docker build time).

Removes the scriptor-markdown-pages VCS entry. The plugin is not in composer.lock (it was never required into the default install), so the only lock change is the content-hash refresh; no dependency changes.

Sites that pull bigins/* plugins must declare the repository on their own side (composer config repositories.x vcs <url>, or the cms-site Docker build-arg).