### PR TITLE
fix(docker): register plugin VCS repos with no-api so public-repo bui…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,11 +79,19 @@ COPY . .
 # Both run after `COPY . .` so the modified composer.json + composer.lock
 # + vendor/ end up consistent in the final image (otherwise COPY would
 # clobber the edits).
+# Each repo is registered with "no-api": true. For github.com URLs
+# Composer otherwise resolves metadata through the GitHub API, which is
+# rate-limited to 60 requests/hour unauthenticated; once exhausted (or
+# for a host with no token) Composer falls back to an SSH git clone that
+# the build container has no key for, and the build fails. "no-api" makes
+# Composer clone the given HTTPS URL anonymously, so public-repo builds
+# are reproducible with no token and no SSH key.
 ARG SCRIPTOR_PLUGIN_REPOS=""
 RUN if [ -n "$SCRIPTOR_PLUGIN_REPOS" ]; then \
         i=0; \
         for url in $SCRIPTOR_PLUGIN_REPOS; do \
-            composer config "repositories.plugin$i" vcs "$url"; \
+            composer config "repositories.plugin$i" \
+                "{\"type\":\"vcs\",\"url\":\"$url\",\"no-api\":true}"; \
             i=$((i+1)); \
         done; \
     fi


### PR DESCRIPTION
…lds are reproducible

The SCRIPTOR_PLUGIN_REPOS loop registered each repo as a plain vcs repo. For github.com URLs Composer resolves package metadata through the GitHub API, rate-limited to 60 req/h unauthenticated. Once that budget is spent Composer falls back to an SSH `git clone git@github.com:...`, which the build container has no key for, and `composer require` fails with exit 1. A cached require layer hid this: the first build of the day reused the layer and never touched the API, so a true --no-cache rebuild was never exercised until it broke a deploy.

- Register each repo as {"type":"vcs","url":...,"no-api":true} so Composer clones the HTTPS URL anonymously and skips the API entirely. Public repos now build with no token and no SSH key; rate limits no longer gate deploys.
- Mechanism stays generic: still no plugin URLs in Scriptor's own composer.json; downstream images supply the repo list as before.